### PR TITLE
restarts and GOFS forcing fixes

### DIFF
--- a/configuration/driver/icepack_drv_init.F90
+++ b/configuration/driver/icepack_drv_init.F90
@@ -103,7 +103,7 @@
       namelist /setup_nml/ &
         days_per_year,  use_leap_years, year_init,       istep0,        &
         dt,             npt,            ndtd,                           &
-        ice_ic,         restart,   &!     restart_dir,     restart_file,  &
+        ice_ic,         restart,        restart_dir, &!    restart_file,  &
         dumpfreq,    &
         diagfreq,       diag_file,                      &
         cpl_bgc
@@ -309,8 +309,7 @@
       diag_len = len(trim(diag_file))
       do n = 1,nx
         diag_file_names=''
-        write(format_str,'(A2,I0,A7)'),'(A',diag_len,',A1,I0)'
-        write(diag_file_names,format_str)trim(diag_file),'.',n
+        write(diag_file_names,'(a,a,i0)') trim(diag_file),'.',n
         write(ice_stdout,*)'    ',trim(diag_file_names)
         open(nu_diag_out+n-1, file=diag_file_names, status='unknown')
       end do

--- a/configuration/scripts/icepack_in
+++ b/configuration/scripts/icepack_in
@@ -8,8 +8,8 @@
     ndtd           = 1
     ice_ic         = 'none'
     restart        = .false.
+    restart_dir    = 'restart/'
     dumpfreq       = 'y'
-    dumpfreq       = 1
     diagfreq       = 24
     diag_file      = 'ice_diag'
     cpl_bgc        = .false.


### PR DESCRIPTION
Changes:
 - allow GOFS forcing to cycle for more than one year
 - do not reset data values for default forcing
 - put restart dumps in restart directory
 - fix format statement for diagnostic output filenames
 - remove redundant dumpfreq from icepack_in
I verified that (manual) restarts work for daily 'd' and annual 'y' restart output, with both the GOFS forcing and the default forcing values.  