### PR TITLE
Climatological forcing and general debugging

### DIFF
--- a/columnphysics/icepack_mechred.F90
+++ b/columnphysics/icepack_mechred.F90
@@ -1604,7 +1604,7 @@
          dh2rdg     ! change in mean value of h^2 per unit area
                     ! consumed by ridging 
 
-      if (kstrength == 1) then  ! Rothrock '75 formulation
+      if (kstrength == 1) then  ! Rothrock 1975 formulation
 
       !-----------------------------------------------------------------
       ! Compute thickness distribution of ridging and ridged ice.

--- a/columnphysics/icepack_orbital.F90
+++ b/columnphysics/icepack_orbital.F90
@@ -39,7 +39,7 @@
       character (len=*), intent(out) :: stop_label
 
       l_stop = .false.      ! initialized for CCSMCOUPLED
-      stop_label = ''       ! initialized for CCSMCOUPLED
+      stop_label = ' '      ! initialized for CCSMCOUPLED
       iyear_AD  = 1950
       log_print = .false.   ! if true, write out orbital parameters
 
@@ -131,8 +131,8 @@ SUBROUTINE shr_orb_params( iyear_AD , eccen , obliq , mvelp    , &
 !-------------------------------------------------------------------------------
 !
 ! Calculate earths orbital parameters using Dave Threshers formula which 
-! came from Berger, Andre.  1978  "A Simple Algorithm to Compute Long-Term 
-! Variations of Daily Insolation".  Contribution 18, Institute of Astronomy 
+! came from Berger, Andre.  1978  A Simple Algorithm to Compute Long-Term 
+! Variations of Daily Insolation.  Contribution 18, Institute of Astronomy 
 ! and Geophysics, Universite Catholique de Louvain, Louvain-la-Neuve, Belgium
 !
 !------------------------------Code history-------------------------------------

--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -1070,8 +1070,8 @@
 !   Compute snow/bare ice/ponded ice shortwave albedos, absorbed and transmitted 
 !   flux using the Delta-Eddington solar radiation method as described in:
 !
-!   "A Delta-Eddington Multiple Scattering Parameterization for Solar Radiation
-!        in the Sea Ice Component of the Community Climate System Model"
+!   A Delta-Eddington Multiple Scattering Parameterization for Solar Radiation
+!        in the Sea Ice Component of the Community Climate System Model
 !            B.P.Briegleb and B.Light   NCAR/TN-472+STR  February 2007
 !
 !   Compute shortwave albedos and fluxes for three surface types: 

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -162,7 +162,7 @@
          dTsf        , & ! Tsf - Tsf_start
          dTi1        , & ! Ti1(1) - Tin_start(1)
          dfsurf_dT   , & ! derivative of fsurf wrt Tsf
-         avg_Tsi     , & ! = 1. if new snow/ice temps avg'd w/starting temps
+         avg_Tsi     , & ! = 1. if new snow/ice temps averaged w/starting temps
          enew            ! new energy of melting after temp change (J m-2)
 
       real (kind=dbl_kind) :: &

--- a/configuration/driver/icepack_drv_flux.F90
+++ b/configuration/driver/icepack_drv_flux.F90
@@ -486,6 +486,7 @@
       vocn  (:) = c0
       frzmlt(:) = c0              ! freezing/melting potential (W/m^2)
       sss   (:) = 34.0_dbl_kind   ! sea surface salinity (ppt)
+      sst   (:) = -1.8_dbl_kind   ! sea surface temperature (C)
 
       do i = 1, nx
          Tf (i) = icepack_liquidus_temperature(sss(i)) ! freezing temp (C)

--- a/configuration/driver/icepack_drv_forcing.F90
+++ b/configuration/driver/icepack_drv_forcing.F90
@@ -224,13 +224,6 @@
       frain(:) = c1intp * frain_data(mlast) + c2intp * frain_data(mnext)
       fsnow(:) = c1intp * fsnow_data(mlast) + c2intp * fsnow_data(mnext)
 
-      if (trim(ocn_data_type) == 'default') return
-
-        sst(:) = c1intp *   sst_data(mlast) + c2intp *   sst_data(mnext)
-        sss(:) = c1intp *   sss_data(mlast) + c2intp *   sss_data(mnext)
-       uocn(:) = c1intp *  uocn_data(mlast) + c2intp *  uocn_data(mnext)
-       vocn(:) = c1intp *  vocn_data(mlast) + c2intp *  vocn_data(mnext)
-
 !for debugging, for now
 if (i==8760) then
 write (nu_diag,*) flw
@@ -250,7 +243,19 @@ write (nu_diag,*) swvdr
 write (nu_diag,*) swvdf
 write (nu_diag,*) swidr
 write (nu_diag,*) swidf
+endif
+
+      if (trim(ocn_data_type) == 'default') return
+
+        sst(:) = c1intp *   sst_data(mlast) + c2intp *   sst_data(mnext)
+        sss(:) = c1intp *   sss_data(mlast) + c2intp *   sss_data(mnext)
+       uocn(:) = c1intp *  uocn_data(mlast) + c2intp *  uocn_data(mnext)
+       vocn(:) = c1intp *  vocn_data(mlast) + c2intp *  vocn_data(mnext)
+
+!for debugging, for now
+if (i==8760) then
 write (nu_diag,*) sst
+write (nu_diag,*) sss
 write (nu_diag,*) uocn
 write (nu_diag,*) vocn
 endif

--- a/configuration/driver/icepack_drv_init.F90
+++ b/configuration/driver/icepack_drv_init.F90
@@ -1001,9 +1001,7 @@
          qsn             ! snow enthalpy (J/m3)
 
       real (kind=dbl_kind), parameter :: &
-         hsno_init = 0.20_dbl_kind   , & ! initial snow thickness (m)
-         edge_init_nh =  70._dbl_kind, & ! initial ice edge, N.Hem. (deg) 
-         edge_init_sh = -60._dbl_kind    ! initial ice edge, S.Hem. (deg)
+         hsno_init = 0.25_dbl_kind   ! initial snow thickness (m)
 
       ! Initialize state variables.
       ! If restarting, these values are overwritten.

--- a/configuration/driver/icepack_drv_init.F90
+++ b/configuration/driver/icepack_drv_init.F90
@@ -316,7 +316,7 @@
 
       diag_len = len(trim(diag_file))
       do n = 1,nx
-        diag_file_names=''
+        diag_file_names=' '
         write(diag_file_names,'(a,a,a)') trim(diag_file),'.',trim(nx_names(n))
         write(ice_stdout,*)'    ',trim(diag_file_names)
         open(nu_diag_out+n-1, file=diag_file_names, status='unknown')
@@ -444,7 +444,7 @@
       endif
 
       if (tr_pond_cesm) then
-            write (nu_diag,*) 'ERROR: formdrag=T but frzpnd=''cesm''' 
+            write (nu_diag,*) 'ERROR: formdrag=T but frzpnd=cesm' 
          stop
       endif
 

--- a/configuration/driver/icepack_drv_init_column.F90
+++ b/configuration/driver/icepack_drv_init_column.F90
@@ -900,8 +900,7 @@
       endif
 
       if ((skl_bgc .AND. solve_zbgc) .or. (skl_bgc .AND. z_tracers)) then
-              print*, 'error:skl_bgc &
-              and solve_zbgc or z_tracers are both true'
+         print*, 'ERROR: skl_bgc and (solve_zbgc or z_tracers) are both true'
          stop
       endif
 

--- a/configuration/driver/icepack_drv_step_mod.F90
+++ b/configuration/driver/icepack_drv_step_mod.F90
@@ -664,6 +664,7 @@
       use icepack_drv_arrays_column, only: Cdn_atm, Cdn_atm_ratio
       use icepack_constants, only: c0, c1000, albocn
       use icepack_intfc, only: icepack_ocn_mixed_layer, icepack_atm_boundary
+      use icepack_drv_init, only: tmask
       use icepack_drv_domain_size, only: nx
       use icepack_drv_flux, only: sst, Tf, Qa, uatm, vatm, wind, potT, rhoa, zlvl, &
            frzmlt, fhocn, fswthru, flw, flwout_ocn, fsens_ocn, flat_ocn, evap_ocn, &
@@ -699,12 +700,14 @@
       !-----------------------------------------------------------------
 
          do i = 1, nx
+            if (.not.tmask(i)) then
                sst       (i) = c0
                frzmlt    (i) = c0
                flwout_ocn(i) = c0
                fsens_ocn (i) = c0
                flat_ocn  (i) = c0
                evap_ocn  (i) = c0
+            endif
          enddo                  ! i
 
       !-----------------------------------------------------------------
@@ -712,7 +715,7 @@
       !-----------------------------------------------------------------
 
             do i = 1, nx
-
+               if (tmask(i)) &
                call icepack_atm_boundary( 'ocn',                &
                                         sst        (i), &    
                                         potT       (i), &
@@ -748,7 +751,7 @@
       ! Compute ocean fluxes and update SST
       !-----------------------------------------------------------------
       do i = 1, nx
-
+         if (tmask(i)) &
          call icepack_ocn_mixed_layer (alvdr_ocn(i), swvdr     (i), &
                                       alidr_ocn(i), swidr     (i), &
                                       alvdf_ocn(i), swvdf     (i), &

--- a/configuration/scripts/icepack_in
+++ b/configuration/scripts/icepack_in
@@ -238,14 +238,15 @@
     update_ocn_f    = .false.
     l_mpond_fresh   = .false.
     tfrz_option     = 'mushy'
+    oceanmixed_ice  = .true.
     precip_units    = 'mks'
     default_season  = 'spring'
-    atm_data_type   = 'GOFS'
+    atm_data_type   = 'clim'
     ocn_data_type   = 'default'
     bgc_data_type   = 'default'
     fyear_init      = 2015
     ycycle          = 1
-    data_dir        = '/Users/ftuser/Desktop/CICE-Consortium/code'
+    data_dir        = '/Users/ftuser/Desktop/CICE-Consortium/ICEPACK_DATA/'
     atm_data_format = 'bin'
     ocn_data_format = 'bin'
     bgc_data_format = 'bin'

--- a/configuration/scripts/tests/timeseries.csh
+++ b/configuration/scripts/tests/timeseries.csh
@@ -21,6 +21,12 @@ set logfile = $1
 foreach field ($fieldlist:q)
   set fieldname = `echo "$field" | sed -e 's/([^()]*)//g'`
   # Create the new data file that houses the timeseries data
+  # assumes daily output
+#  awk -v field="$fieldname" \
+#      '$0 ~ field {count++; print int(count/365)+1"-"count % 365 ","$(NF-1)","$NF}' \
+#      $logfile > data.txt
+
+  # assumes hourly output
   awk -v field="$fieldname" \
       '$0 ~ field {count++; print int(count/24)+1"-"count % 24 ","$(NF-1)","$NF}' \
       $logfile > data.txt
@@ -44,6 +50,7 @@ set terminal png size 1920,960
 set xdata time
 set timefmt "%j-%H"
 set format x "%Y/%m/%d"
+#set format x "%Y/%d"
 
 # Axis tick marks
 set xtics rotate
@@ -54,10 +61,10 @@ set xlabel "Simulation Day"
 
 set key left top
 
-plot "data.txt" using (timecolumn(1)-63072000):2 with lines lw 2 lt 3 title "Arctic", \
-     "" using (timecolumn(1)-63072000):3 with lines lw 2 lt 1 title "Antarctic"
+plot "data.txt" using (timecolumn(1)-63072000):3 with lines lw 2 lt 1 title " "
+
 EOF
 
 # Delete the data file
-rm data.txt
+/bin/rm data.txt
 end


### PR DESCRIPTION
Adding climatological forcing, which requires interpolation, and debugging/cleaning up the forcing module.  I still consider this part of the code to be in process - there will likely be more answer-changes before it settles down.
Developer(s): E. Hunke, Mike Winton
Updated documentation (Y/N): not yet
Results (bit for bit, roundoff, climate changing):  changes answers - fixed lots of bugs in the forcing and also set atm_data_type = 'clim' in icepack_in (was GOFS)
Code review: 
Other Relevant Details:
- Many bugs associated with ocean forcing, including initialization, missing land mask that was resetting everything to zero, sss set to sst value, qdp not initialized.  Note qdp is set in climatological atmo forcing, which is inconsistent and should be generalized at some point.
- Switched GOFS to new data file that includes wind instead of latent and sensible heat; not debugged.
- Added climatological forcing provided by M. Winton, GFDL.
- Cleaned up "unmatched quotes" in comments that gfortran complains about
- subroutine interp_coeff_monthly is used; also added general interp_coeff routine but it is not yet called.
- timeseries.csh no longer tries to plot both Arctic and Antarctic data, which is not available in Icepack's output data files.  However, I did not figure out how to fix the x axis (currently hardwired for hourly output - the default is daily output), or the legend.   @mattdturner do you know how to fix this?

