### PR TITLE
Update timeseries.csh script

### DIFF
--- a/configuration/scripts/icepack.batch.csh
+++ b/configuration/scripts/icepack.batch.csh
@@ -75,6 +75,18 @@ cat >> ${jobfile} << EOFB
 ###PBS -m be
 EOFB
 
+else if (${ICE_MACHINE} =~ onyx*) then
+cat >> ${jobfile} << EOFB
+#PBS -N ${ICE_CASENAME}
+#PBS -q debug
+#PBS -A ${acct}
+#PBS -l select=${nnodes}:ncpus=${maxtpn}:mpiprocs=${taskpernode}
+#PBS -l walltime=${ICE_RUNLENGTH}
+#PBS -j oe
+###PBS -M username@domain.com
+###PBS -m be
+EOFB
+
 else if (${ICE_MACHINE} =~ cori*) then
 cat >> ${jobfile} << EOFB
 #SBATCH -J ${ICE_CASENAME}

--- a/configuration/scripts/machines/Macros.onyx
+++ b/configuration/scripts/machines/Macros.onyx
@@ -1,0 +1,63 @@
+#==============================================================================
+# Macros file for NAVYDSRC conrad, intel compiler
+#==============================================================================
+
+CPP        := fpp
+CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${ICE_CPPDEFS}
+CFLAGS     := -c -O2 -fp-model precise   -xHost
+
+FIXEDFLAGS := -132
+FREEFLAGS  := -FR
+FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback   -xHost
+FFLAGS_NOOPT:= -O0
+
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+else
+  FFLAGS     += -O2
+endif
+
+ifeq ($(ICE_COMMDIR), mpi)
+  FC         := ftn
+else
+  FC         := ftn
+endif
+
+MPICC:= cc
+
+MPIFC:= ftn
+LD:= $(MPIFC)
+
+# defined by module
+#NETCDF_PATH := $(NETCDF)
+#PNETCDF_PATH := $(PNETCDF)
+#PNETCDF_PATH := /glade/apps/opt/pnetcdf/1.3.0/intel/default
+#LAPACK_LIBDIR := /glade/apps/opt/lapack/3.4.2/intel/12.1.5/lib
+
+#PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
+
+INCLDIR := $(INCLDIR)
+#INCLDIR += -I$(NETCDF_PATH)/include
+
+#LIB_NETCDF := $(NETCDF_PATH)/lib
+#LIB_PNETCDF := $(PNETCDF_PATH)/lib
+#LIB_MPI := $(IMPILIBDIR)
+#SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
+
+SCC:= icc 
+
+SFC:= ifort 
+
+ifeq ($(ICE_THREADED), true) 
+   LDFLAGS += -openmp
+   CFLAGS += -openmp
+   FFLAGS += -openmp
+endif
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first!
+ifeq ($(ICE_IOTYPE), pio)
+   PIO_PATH:=/glade/u/home/jedwards/pio1_6_5/pio
+   INCLDIR += -I$(PIO_PATH)
+   SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpio
+endif
+

--- a/configuration/scripts/machines/env.onyx
+++ b/configuration/scripts/machines/env.onyx
@@ -1,0 +1,47 @@
+#!/bin/csh -f
+
+source /opt/modules/default/init/csh
+
+module unload PrgEnv-cray
+module unload PrgEnv-gnu
+module unload PrgEnv-intel
+module unload PrgEnv-pgi
+module load PrgEnv-intel/6.0.4
+
+module unload intel
+module load intel/17.0.1.132
+
+module unload cray-mpich
+module unload cray-mpich2
+module load cray-mpich/7.6.2
+
+module unload netcdf
+module unload cray-hdf5
+module unload cray-hdf5-parallel
+module unload cray-netcdf-hdf5parallel
+module unload cray-parallel-netcdf
+module load cray-netcdf/4.4.1.1.3
+module load cray-hdf5/1.10.0.3
+
+module unload cray-libsci
+
+module load craype-broadwell
+
+setenv NETCDF_PATH ${NETCDF_DIR}
+limit coredumpsize unlimited
+limit stacksize unlimited
+
+setenv ICE_MACHINE_ENVNAME onyx
+setenv ICE_MACHINE_MAKE gmake
+setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
+setenv ICE_MACHINE_INPUTDATA /p/home/turner/CICE-atm/
+setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
+setenv ICE_MACHINE_SUBMIT "qsub "
+setenv ICE_MACHINE_ACCT ARLAP96070PET
+setenv ICE_MACHINE_TPNODE 44    # tasks per node
+setenv ICE_MACHINE_BLDTHRDS 12
+
+if (-e ~/.cice_proj) then
+   set account_name = `head -1 ~/.cice_proj`
+   setenv ICE_MACHINE_ACCT ${account_name}
+endif


### PR DESCRIPTION
Update the timeseries.csh script to automatically detect dates/times for output steps.  Also allow for setting x-axis and y-axis limits.
Developer(s): Matt Turner
Updated documentation (Y/N): N
Results (bit for bit, roundoff, climate changing): N/A (no changes to Icepack code)
Code review: 
Other Relevant Details:
- These changes are nearly identical to the recent CICE pull request.
- The y-axis limits are hard-coded for the 3 variables currently plotted.
- Also added machine files for the new ERDC Onyx server
