### PR TITLE
Icepack ctest submit failure

### DIFF
--- a/configuration/scripts/icepack.run.suite
+++ b/configuration/scripts/icepack.run.suite
@@ -182,7 +182,7 @@ cd base_suite.${testid}
 
 ./results.csh
 
-ctest -S steer.cmake
+./run_ctest.csh
 
 cd ..
 

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/csh
+#!/bin/csh -f
 
 set initargv = ( $argv[*] )
 

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -21,7 +21,7 @@ if ( $submit_only == 0 ) then
   ctest -S steer.cmake
 else
   # Find the filename to submit to CDash
-  set CTEST_TAG="`head -n 1 Testing/TAG`"
+  set CTEST_TAG="`head -n 1 Testing/TAG.submit`"
   
 cat > submit.cmake << EOF0
 cmake_minimum_required(VERSION 2.8)
@@ -55,7 +55,8 @@ if ( $submit_only == 0 ) then
     if ( $success == 0 ) then
         echo ""
         set xml_file="Testing/$CTEST_TAG/Test.xml"
-        tar czf icepack_ctest.tgz run_ctest.csh CTestConfig.cmake Testing/TAG \
+        cp Testing/TAG Testing/TAG.submit
+        tar czf icepack_ctest.tgz run_ctest.csh CTestConfig.cmake Testing/TAG.submit \
                                       Testing/${CTEST_TAG}/Test.xml
         echo "CTest submission failed.  To try the submission again run "
         echo "    ./run_ctest.csh -submit"

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -1,0 +1,71 @@
+#!/usr/bin/csh
+
+set initargv = ( $argv[*] )
+
+set dash = "-"
+set submit_only=0
+
+# Read in command line arguments
+set argv = ( $initargv[*] )
+
+while (1)
+  if ( $#argv < 1 ) break;
+  if ("$argv[1]" == "${dash}submit") then
+    set submit_only=1
+    shift argv
+    continue
+  endif
+end
+
+if ( $submit_only == 0 ) then
+  ctest -S steer.cmake
+else
+  # Find the filename to submit to CDash
+  set CTEST_TAG="`head -n 1 Testing/TAG`"
+  
+cat > submit.cmake << EOF0
+cmake_minimum_required(VERSION 2.8)
+set(CTEST_DASHBOARD_ROOT   "\$ENV{PWD}")
+set(CTEST_SOURCE_DIRECTORY "\$ENV{PWD}")
+set(CTEST_BINARY_DIRECTORY "\$ENV{PWD}")
+message("source directory = \${CTEST_SOURCE_DIRECTORY}")
+
+include( CTestConfig.cmake )
+
+ctest_start("Experimental")
+ctest_submit(FILES "`pwd`/Testing/${CTEST_TAG}/Test.xml")
+EOF0
+  ctest -S submit.cmake
+endif
+
+if ( $submit_only == 0 ) then
+  if ( -f Testing/TAG ) then
+    set file='Testing/TAG'
+    set CTEST_TAG="`head -n 1 $file`"
+
+    # Check to see if ctest_submit was successful
+    set success=0
+    set submit_file="Testing/Temporary/LastSubmit_$CTEST_TAG.log"
+    foreach line ("`cat $submit_file`")
+        if ( "$line" =~ *'Submission successful'* ) then
+            set success=1
+        endif
+    end
+
+    if ( $success == 0 ) then
+        echo ""
+        set xml_file="Testing/$CTEST_TAG/Test.xml"
+        tar czf icepack_ctest.tgz run_ctest.csh CTestConfig.cmake Testing/TAG \
+                                      Testing/${CTEST_TAG}/Test.xml
+        echo "CTest submission failed.  To try the submission again run "
+        echo "    ./run_ctest.csh -submit"
+        echo "If you wish to submit the test results from another server, copy the "
+        echo "icepack_ctest.tgz file to another server and run "
+        echo "    ./run_ctest.csh -submit"
+    else
+        echo "Submit Succeeded"
+    endif
+  else
+    echo "No Testing/TAG file exists.  Ensure that ctest is installed on this system."
+  endif
+endif

--- a/doc/source/icepack_3_user_guide.rst
+++ b/doc/source/icepack_3_user_guide.rst
@@ -1005,7 +1005,7 @@ The run.suite script does the following:
 - ``run.suite`` monitors the queue manager to determine when all jobs have
   finished (pings the queue manager once every 5 minutes).
 - Once all jobs complete, cd to base_suite directory and run ``./results.csh``
-- Run ``ctest -S steer.cmake`` in order to post the test results to the CDash dashboard
+- Run ``./run_ctest.csh`` in order to post the test results to the CDash dashboard
 
 *****************
 Manual Method
@@ -1021,8 +1021,14 @@ users essentially just need to perform all steps available in run.suite, detaile
   queue manager.
 - After every job has been submitted and completed, ``cd`` to the suite directory.
 - Parse the results, by running ``./results.csh``.
-- Run the CTest / CDash script ``ctest -S steer.cmake``.
+- Run the CTest / CDash script ``./run_ctest.csh``.
 
+If the ``run_ctest.csh`` script is unable to post the testing results to the CDash
+server, a message will be printed to the screen detailing instructions on how to attempt
+to post the results from another server.  If ``run_ctest.csh`` fails to submit the results,
+it will generate a tarball ``icepack_ctest.tgz`` that contains the necessary files for
+submission.  Copy this file to another server (CMake version 2.8+ required), extract the
+archive, and run ``./run_ctest.csh -submit``.
 
 .. _tabnamelist:
 

--- a/icepack.create.case
+++ b/icepack.create.case
@@ -230,6 +230,7 @@ if ( $testsuite != $spval ) then
     cp -f ${ICE_SCRIPTS}/tests/CTest/CTestConfig.cmake ./${tsdir}
     cp -f ${ICE_SCRIPTS}/tests/CTest/CTestTestfile.cmake ./${tsdir}
     cp -f ${ICE_SCRIPTS}/tests/CTest/steer.cmake ./${tsdir}
+    cp -f ${ICE_SCRIPTS}/tests/CTest/run_ctest.csh ./${tsdir}
   endif
 
 cat >! ./${tsdir}/suite.run << EOF0


### PR DESCRIPTION
Add a backup option for submitting the CTest results to CDash
Developer(s): Matt Turner
Updated documentation (Y/N): Y
Results (bit for bit, roundoff, climate changing): N/A
Code review: 
Other Relevant Details:

