### PR TITLE
Option to pass account number to icepack.create.case

### DIFF
--- a/doc/source/icepack_3_user_guide.rst
+++ b/doc/source/icepack_3_user_guide.rst
@@ -416,6 +416,8 @@ icepack.create.case generates a case. Use ``create.case -h`` for help with the t
 
   -m is the machine name (required). Currently, there are working ports for NCAR yellowstone and cheyenne, AFRL thunder, NavyDSRC gordon and conrad, and LANL’s wolf machines.
 
+  -a is the account number for the queue manager (default is defined in env.<machine>)
+
   -s are comma separated optional env or namelist settings (default is 'null')
 
   -t is the test name and location (cannot be used with -c).

--- a/icepack.create.case
+++ b/icepack.create.case
@@ -19,6 +19,7 @@ set sets = ""
 set bdir = $spval
 set testid = $spval
 set testsuite = $spval
+set acct = $spval
 set baseCom = $spval  # Baseline compare
 set baseGen = $spval  # Baseline generate
 set bfbcomp = $spval  # BFB compare
@@ -57,6 +58,8 @@ EOF1
       end
 cat << EOF1
         -p tasks x threads, mxn (default is 1x1)
+        -a account number for the queue manager (default is defined in env.<machine>
+           or in ~/.cice.proj)
         -g grid, grid (default = col)
         -s build and namelist mod files, comma separated with no spaces (default = " ")
            Available -s options are in configuration/scripts/options and include:
@@ -138,6 +141,9 @@ while (1)
       breaksw
     case "-g":
       set grid = $argv[1]
+      breaksw
+    case "-a":
+      set acct = $argv[1]
       breaksw
     case "-p":
       set pesx = $argv[1]
@@ -365,6 +371,10 @@ echo ICE_SANDBOX  = ${ICE_SANDBOX}
 echo ICE_CASENAME = ${casename}
 echo ICE_CASEDIR  = ${casedir}
 echo ICE_MACHINE  = ${mach}
+
+if ( $acct != $spval ) then
+  echo $acct > ~/.cice_proj
+endif
 
 #------------------------------------------------------------
 # Compute a default blocksize

--- a/icepack.create.case
+++ b/icepack.create.case
@@ -58,8 +58,7 @@ EOF1
       end
 cat << EOF1
         -p tasks x threads, mxn (default is 1x1)
-        -a account number for the queue manager (default is defined in env.<machine>
-           or in ~/.cice.proj)
+        -a account number for the queue manager (default is defined in env.<machine>)
         -g grid, grid (default = col)
         -s build and namelist mod files, comma separated with no spaces (default = " ")
            Available -s options are in configuration/scripts/options and include:


### PR DESCRIPTION
This pull request adds a '-a' option to icepack.create.case to allow users to pass the queue manager account number as an optional argument.
Developer(s): Matt Turner
Updated documentation (Y/N): Y
Results (bit for bit, roundoff, climate changing): N/A
Code review: 
Other Relevant Details:

The way this works is by having icepack.create.case write the account number (if it is passed as an argument) to ~/.cice.proj.  The env.<machine> file then reads the account number from ~/.cice.proj.  I have no knowledge of what ~/.cice.proj is used for, so this pull request should be rejected if these edits might break some other functionality.