### PR TITLE
Icepack.create.case option to pass account number

### DIFF
--- a/configuration/scripts/icepack.batch.csh
+++ b/configuration/scripts/icepack.batch.csh
@@ -14,7 +14,7 @@ set jobfile = $1
 set ntasks = ${ICE_NTASKS}
 set nthrds = ${ICE_NTHRDS}
 set maxtpn = ${ICE_MACHINE_TPNODE}
-set acct   = ${ICE_MACHINE_ACCT}
+set acct   = ${ICE_ACCOUNT}
 
 @ ncores = ${ntasks} * ${nthrds}
 @ taskpernode = ${maxtpn} / $nthrds
@@ -61,7 +61,7 @@ cat >> ${jobfile} << EOFB
 #PBS -V
 #PBS -q share
 #PBS -N ${ICE_CASENAME}
-#PBS -A ${ICE_MACHINE_ACCT}
+#PBS -A ${acct}
 #PBS -l select=${nnodes}:ncpus=${corespernode}:mpiprocs=${taskpernodelimit}:ompthreads=${nthrds}
 #PBS -l walltime=${ICE_RUNLENGTH}
 EOFB

--- a/configuration/scripts/icepack.batch.csh
+++ b/configuration/scripts/icepack.batch.csh
@@ -61,7 +61,7 @@ cat >> ${jobfile} << EOFB
 #PBS -V
 #PBS -q share
 #PBS -N ${ICE_CASENAME}
-#PBS -A ${ICE_ACCT}
+#PBS -A ${ICE_MACHINE_ACCT}
 #PBS -l select=${nnodes}:ncpus=${corespernode}:mpiprocs=${taskpernodelimit}:ompthreads=${nthrds}
 #PBS -l walltime=${ICE_RUNLENGTH}
 EOFB

--- a/configuration/scripts/icepack.run.suite
+++ b/configuration/scripts/icepack.run.suite
@@ -12,6 +12,7 @@ set mach = $spval
 set baseCom = $spval
 set baseGen = $spval
 set testid = $spval
+set acct = $spval
 
 if ($#argv < 1) then
   set helpheader = 1
@@ -39,6 +40,7 @@ NAME
                 3. Run the full base_suite
                 4. Post the results of the suite to CDash
         -h help
+        -a account number for the queue manager (default is defined in env.<machine>)
         -m machine, machine name (required)
            Available -m options are in configuration/scripts/machines and include:
 EOF1
@@ -84,6 +86,9 @@ while (1)
     case "-m":
       set mach = $argv[1]
       breaksw
+    case "-a":
+      set acct = $argv[1]
+      breaksw
     case "-bc":
       set baseCom = $argv[1]
       breaksw
@@ -118,10 +123,22 @@ git clone https://github.com/CICE-Consortium/Icepack.git $gitDir
 cd $gitDir
 
 echo "Running ./icepack.create.case and storing output in log.suite"
-if ($baseGen == $spval) then
-  ./icepack.create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -report >& log.suite
+if ($acct == $spval) then
+  if ($baseGen == $spval) then
+    ./icepack.create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -report \
+           >& log.suite
+  else
+    ./icepack.create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg \
+           ${baseGen} -report >& log.suite
+  endif
 else
-  ./icepack.create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg ${baseGen} -report >& log.suite
+  if ($baseGen == $spval) then
+    ./icepack.create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -report \
+           -a $acct >& log.suite
+  else
+    ./icepack.create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg \
+           ${baseGen} -report -a $acct >& log.suite
+  endif
 endif
 
 # Parse the job IDs from log.suite.  This should work for PBS, Slurm, or IBM LFS but needs

--- a/configuration/scripts/icepack.settings
+++ b/configuration/scripts/icepack.settings
@@ -27,6 +27,7 @@ setenv ICE_BASECOM    undefined
 setenv ICE_BFBCOMP    undefined
 setenv ICE_SPVAL      undefined
 setenv ICE_RUNLENGTH  00:10:00
+setenv ICE_ACCOUNT    undefined
 
 #======================================================
 

--- a/configuration/scripts/machines/env.cheyenne
+++ b/configuration/scripts/machines/env.cheyenne
@@ -15,14 +15,6 @@ setenv ICE_MACHINE_WKDIR /glade/scratch/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/p/cesm/pcwg_dev
 setenv ICE_MACHINE_BASELINE /glade/scratch/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub"
-setenv ICE_MACHINE_ACCT_D P00000000
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 36
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.cheyenne
+++ b/configuration/scripts/machines/env.cheyenne
@@ -15,11 +15,14 @@ setenv ICE_MACHINE_WKDIR /glade/scratch/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/p/cesm/pcwg_dev
 setenv ICE_MACHINE_BASELINE /glade/scratch/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub"
+setenv ICE_MACHINE_ACCT_D P00000000
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 36
-setenv ICE_MACHINE_ACCT P0000000
 setenv ICE_MACHINE_BLDTHRDS 1
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.conrad
+++ b/configuration/scripts/machines/env.conrad
@@ -37,11 +37,14 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT ARLAP96070PET
+setenv ICE_MACHINE_ACCT_D ARLAP96070PET
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.conrad
+++ b/configuration/scripts/machines/env.conrad
@@ -37,14 +37,6 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT_D ARLAP96070PET
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT ARLAP96070PET
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.cori
+++ b/configuration/scripts/machines/env.cori
@@ -39,14 +39,6 @@ setenv ICE_MACHINE_WKDIR $SCRATCH/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /global/homes/t/tcraig/cice_consortium
 setenv ICE_MACHINE_BASELINE $SCRATCH/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch "
-setenv ICE_MACHINE_ACCT_D P00000000
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.cori
+++ b/configuration/scripts/machines/env.cori
@@ -39,11 +39,14 @@ setenv ICE_MACHINE_WKDIR $SCRATCH/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /global/homes/t/tcraig/cice_consortium
 setenv ICE_MACHINE_BASELINE $SCRATCH/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch "
-setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_ACCT_D P00000000
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.gordon
+++ b/configuration/scripts/machines/env.gordon
@@ -37,11 +37,14 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_ACCT_D P00000000
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.gordon
+++ b/configuration/scripts/machines/env.gordon
@@ -37,14 +37,6 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT_D P00000000
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.loft
+++ b/configuration/scripts/machines/env.loft
@@ -8,11 +8,14 @@ setenv ICE_MACHINE_WKDIR /Users/$user/Desktop/CICE-Consortium/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /Users/$user/Desktop/CICE-Consortium
 setenv ICE_MACHINE_BASELINE /Users/$user/Desktop/CICE-Consortium/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT " "
-setenv ICE_MACHINE_ACCT 
+setenv ICE_MACHINE_ACCT_D 
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 1
 setenv ICE_MACHINE_BLDTHRDS 1
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.loft
+++ b/configuration/scripts/machines/env.loft
@@ -8,14 +8,6 @@ setenv ICE_MACHINE_WKDIR /Users/$user/Desktop/CICE-Consortium/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /Users/$user/Desktop/CICE-Consortium
 setenv ICE_MACHINE_BASELINE /Users/$user/Desktop/CICE-Consortium/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT " "
-setenv ICE_MACHINE_ACCT_D 
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT 
 setenv ICE_MACHINE_TPNODE 1
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.onyx
+++ b/configuration/scripts/machines/env.onyx
@@ -37,11 +37,14 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/app/unsupported/RASM/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT ARLAP96070PET
+setenv ICE_MACHINE_ACCT_D P00000000
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 44    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 12
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.onyx
+++ b/configuration/scripts/machines/env.onyx
@@ -37,14 +37,6 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/app/unsupported/RASM/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT_D P00000000
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 44    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 12
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.pinto
+++ b/configuration/scripts/machines/env.pinto
@@ -23,11 +23,14 @@ setenv ICE_MACHINE_WKDIR /net/scratch3/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /usr/projects/climate/eclare/DATA/Consortium
 setenv ICE_MACHINE_BASELINE /net/scratch3/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch "
-setenv ICE_MACHINE_ACCT climateacme
+setenv ICE_MACHINE_ACCT_D climateacme
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 16
 setenv ICE_MACHINE_BLDTHRDS 1
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.pinto
+++ b/configuration/scripts/machines/env.pinto
@@ -23,14 +23,6 @@ setenv ICE_MACHINE_WKDIR /net/scratch3/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /usr/projects/climate/eclare/DATA/Consortium
 setenv ICE_MACHINE_BASELINE /net/scratch3/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch "
-setenv ICE_MACHINE_ACCT_D climateacme
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT climateacme
 setenv ICE_MACHINE_TPNODE 16
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.testmachine
+++ b/configuration/scripts/machines/env.testmachine
@@ -7,13 +7,5 @@ setenv ICE_MACHINE_INPUTDATA ~/ICEPACK_INPUTDATA
 setenv ICE_MACHINE_BASELINE ~/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub"
 setenv ICE_MACHINE_TPNODE 4
-setenv ICE_MACHINE_ACCT_D P0000000
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT P0000000
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.testmachine
+++ b/configuration/scripts/machines/env.testmachine
@@ -7,10 +7,13 @@ setenv ICE_MACHINE_INPUTDATA ~/ICEPACK_INPUTDATA
 setenv ICE_MACHINE_BASELINE ~/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub"
 setenv ICE_MACHINE_TPNODE 4
-setenv ICE_MACHINE_ACCT P0000000
+setenv ICE_MACHINE_ACCT_D P0000000
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_BLDTHRDS 1
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.thunder
+++ b/configuration/scripts/machines/env.thunder
@@ -31,14 +31,6 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work2/projects/rasm/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT_D P00000000
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 36    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.thunder
+++ b/configuration/scripts/machines/env.thunder
@@ -31,11 +31,14 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work2/projects/rasm/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_ACCT_D P00000000
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 36    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.wolf
+++ b/configuration/scripts/machines/env.wolf
@@ -23,11 +23,14 @@ setenv ICE_MACHINE_WKDIR /net/scratch3/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /usr/projects/climate/eclare/DATA/Consortium
 setenv ICE_MACHINE_BASELINE /net/scratch3/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch "
-setenv ICE_MACHINE_ACCT climateacme
+setenv ICE_MACHINE_ACCT_D climateacme
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 16
 setenv ICE_MACHINE_BLDTHRDS 1
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/configuration/scripts/machines/env.wolf
+++ b/configuration/scripts/machines/env.wolf
@@ -23,14 +23,6 @@ setenv ICE_MACHINE_WKDIR /net/scratch3/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /usr/projects/climate/eclare/DATA/Consortium
 setenv ICE_MACHINE_BASELINE /net/scratch3/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch "
-setenv ICE_MACHINE_ACCT_D climateacme
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT climateacme
 setenv ICE_MACHINE_TPNODE 16
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.yellowstone
+++ b/configuration/scripts/machines/env.yellowstone
@@ -27,14 +27,6 @@ setenv ICE_MACHINE_WKDIR /glade/scratch/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/p/cesm/pcwg_dev
 setenv ICE_MACHINE_BASELINE /glade/scratch/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "bsub < "
-setenv ICE_MACHINE_ACCT_D P00000000
-setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
+setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 32
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
-  if (-e ~/.cice_proj) then
-    set account_name = `head -1 ~/.cice_proj`
-    setenv ICE_MACHINE_ACCT ${account_name}
-  endif
-endif

--- a/configuration/scripts/machines/env.yellowstone
+++ b/configuration/scripts/machines/env.yellowstone
@@ -27,11 +27,14 @@ setenv ICE_MACHINE_WKDIR /glade/scratch/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/p/cesm/pcwg_dev
 setenv ICE_MACHINE_BASELINE /glade/scratch/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "bsub < "
-setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_ACCT_D P00000000
+setenv ICE_MACHINE_ACCT ${ICE_MACHINE_ACCT_D}
 setenv ICE_MACHINE_TPNODE 32
 setenv ICE_MACHINE_BLDTHRDS 4
 
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
+if ( "$ICE_MACHINE_ACCT" == "$ICE_MACHINE_ACCT_D" ) then
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    setenv ICE_MACHINE_ACCT ${account_name}
+  endif
 endif

--- a/doc/source/icepack_3_user_guide.rst
+++ b/doc/source/icepack_3_user_guide.rst
@@ -416,6 +416,8 @@ icepack.create.case generates a case. Use ``create.case -h`` for help with the t
 
   -m is the machine name (required). Currently, there are working ports for NCAR yellowstone and cheyenne, AFRL thunder, NavyDSRC gordon and conrad, and LANL’s wolf machines.
 
+  -a is the account number for the queue manager.  The default is set in env.<machine>
+
   -s are comma separated optional env or namelist settings (default is 'null')
 
   -t is the test name and location (cannot be used with -c).
@@ -993,7 +995,7 @@ users need to copy and run the ``icepack.run.suite`` script:
 .. code-block:: bash
 
   cp configuration/scripts/icepack.run.suite .
-  ./icepack.run.suite -m <machine> -testid <test_id> -bc <baseline_to_compare> -bg <baseline_to_generate>
+  ./icepack.run.suite -m <machine> -testid <test_id> -bc <baseline_to_compare> -bg <baseline_to_generate> -a <account_number>
 
 The run.suite script does the following:
 

--- a/icepack.create.case
+++ b/icepack.create.case
@@ -457,6 +457,17 @@ else
   echo "setenv ICE_TESTNAME ${spval}" >> ${fsmods}
 endif
 
+if ($acct != $spval) then
+  echo "setenv ICE_ACCOUNT ${acct}" >> ${fsmods}
+else
+  if (-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    echo "setenv ICE_ACCOUNT ${account_name}" >> ${fsmods}
+  else
+    echo "setenv ICE_ACCOUNT ${ICE_MACHINE_ACCT}" >> ${fsmods}
+  endif
+endif
+
 if ($sets != "") then
   set setsx = `echo $sets | sed 's/,/ /g'`
 else

--- a/icepack.create.case
+++ b/icepack.create.case
@@ -348,11 +348,6 @@ foreach file (env.${mach} Macros.${mach})
   cp -f -p ${ICE_SCRIPTS}/machines/$file ${casedir}
 end
 
-# If account number is passed as argument, replace account number in env.<machine>
-if ( $acct != $spval ) then
-  sed -i "s/^\(.*\)\("'$'"{ICE_MACHINE_ACCT_D}\)/\1$acct /" ${casedir}/env.${mach}
-endif
-
 # from basic script dir to casescr
 foreach file (parse_namelist.sh parse_settings.sh parse_namelist_from_settings.sh icepack_decomp.csh icepack.run.setup.csh icepack.test.setup.csh)
   if !(-e ${ICE_SCRIPTS}/$file) then

--- a/icepack.create.case
+++ b/icepack.create.case
@@ -19,6 +19,7 @@ set sets = ""
 set bdir = $spval
 set testid = $spval
 set testsuite = $spval
+set acct = $spval
 set baseCom = $spval  # Baseline compare
 set baseGen = $spval  # Baseline generate
 set bfbcomp = $spval  # BFB compare
@@ -57,6 +58,7 @@ EOF1
       end
 cat << EOF1
         -p tasks x threads, mxn (default is 1x1)
+        -a account number for the queue manager (default is defined in env.<machine>)
         -g grid, grid (default = col)
         -s build and namelist mod files, comma separated with no spaces (default = " ")
            Available -s options are in configuration/scripts/options and include:
@@ -141,6 +143,9 @@ while (1)
       breaksw
     case "-p":
       set pesx = $argv[1]
+      breaksw
+    case "-a":
+      set acct = $argv[1]
       breaksw
     case "-s":
       set sets = $argv[1]
@@ -342,6 +347,11 @@ foreach file (env.${mach} Macros.${mach})
   endif
   cp -f -p ${ICE_SCRIPTS}/machines/$file ${casedir}
 end
+
+# If account number is passed as argument, replace account number in env.<machine>
+if ( $acct != $spval ) then
+  sed -i "s/^\(.*\)\("'$'"{ICE_MACHINE_ACCT_D}\)/\1$acct /" ${casedir}/env.${mach}
+endif
 
 # from basic script dir to casescr
 foreach file (parse_namelist.sh parse_settings.sh parse_namelist_from_settings.sh icepack_decomp.csh icepack.run.setup.csh icepack.test.setup.csh)


### PR DESCRIPTION
Add option to pass account number to Icepack create.cast
Developer(s): Matt Turner
Updated documentation (Y/N): Y
Results (bit for bit, roundoff, climate changing): N/A
Code review: 
Other Relevant Details:

As it is currently setup, the priority for defining the account number is as follows:
    default defined in env.<machine> < ~/.cice_proj < icepack.create.case -a
In other words, passing an account number to icepack.create.case via the '-a' option overwrites all others.  These edits to env.<machine> are made in the case directory only.