### PR TITLE
send nilyr instead of ncat to subroutine absorbed_solar

### DIFF
--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -102,9 +102,11 @@
                                   fswthru,  fswpenl,  &
                                   Iswabs,   SSwabs,   &
                                   albin,    albsn,    &
-                                  coszen,   ncat)
+                                  coszen,   ncat,     &
+                                  nilyr)
 
       integer (kind=int_kind), intent(in) :: &
+         nilyr    , & ! number of ice layers
          ncat         ! number of ice thickness categories
 
       real (kind=dbl_kind), dimension (:), intent(in) :: &
@@ -263,7 +265,7 @@
       !-----------------------------------------------------------------
 
          call absorbed_solar  (heat_capacity,        &
-                               ncat,                 &
+                               nilyr,                &
                                aicen(n),             &
                                vicen(n),             &
                                vsnon(n),             &
@@ -4148,7 +4150,8 @@
                                  Iswabsn,                &
                                  Sswabsn,                &
                                  albicen,    albsnon,    &
-                                 coszen,     ncat)
+                                 coszen,     ncat,       &
+                                 nilyr)
             if (icepack_warnings_aborted(subname)) return
 
          else


### PR DESCRIPTION
bug fix for array-out-of-bounds error  
Developer(s):  E. Hunke
Updated documentation (Y/N):  N
Results (bit for bit, roundoff, climate changing):  BFB in standard configurations
Code review: 
Other Relevant Details:
bug fix for array-out-of-bounds error when using zero-layer thermo (ktherm=0) with ccsm3 shortwave:  ncat was sent to the routine absorbed_solar instead of nilyr.
addresses issue #45