### PR TITLE
Automatically determine restart date-time group

### DIFF
--- a/configuration/scripts/options/test_nml.restart2
+++ b/configuration/scripts/options/test_nml.restart2
@@ -1,5 +1,2 @@
-npt            = 8760
-ice_ic         = './restart/iced.2015-03-01-00000'
 restart        = .true.
 dumpfreq       = 'm'
-

--- a/configuration/scripts/tests/test_restart.script
+++ b/configuration/scripts/tests/test_restart.script
@@ -17,13 +17,31 @@ else
 endif
 
 # Copy restart files to baseline directory 
-set test_file = `ls -t1 ${ICE_RUNDIR}/restart | head -1`
+set test_file = `ls -1 ${ICE_RUNDIR}/restart | tail -1`
+if ( -d ${ICE_RUNDIR}/restart_baseline ) then
+  rm -rf ${ICE_RUNDIR}/restart_baseline
+endif
 mv ${ICE_RUNDIR}/restart ${ICE_RUNDIR}/restart_baseline
 mkdir ${ICE_RUNDIR}/diags_baseline
 mv ${ICE_RUNDIR}/ice_diag.* ${ICE_RUNDIR}/diags_baseline/
 
 mkdir ${ICE_RUNDIR}/restart
-cp -f ${ICE_RUNDIR}/restart_baseline/iced.2015-03-01-00000 ${ICE_RUNDIR}/restart/
+# Determine the restart file to use
+set numfiles=`ls ${ICE_RUNDIR}/restart_baseline/iced.* | wc -l`
+@ halffiles = $numfiles / 2
+@ cnt = 0
+foreach file (`ls ${ICE_RUNDIR}/restart_baseline/iced.*`)
+    @ cnt += 1
+    if ( $cnt == $halffiles ) then
+        set fname=$file
+        break
+    endif
+end
+cp -f ${fname} ${ICE_RUNDIR}/restart/
+
+# Calculate the 'npt' for the restart run
+set npt=`grep "npt " icepack_in.1 | grep -oP "\d+" | sort -n | tail -1`
+@ new_npt = $npt / 2
 
 set base_data = ${ICE_RUNDIR}/restart_baseline/${test_file}
 set test_data = ${ICE_RUNDIR}/restart/${test_file}
@@ -31,6 +49,8 @@ set test_data = ${ICE_RUNDIR}/restart/${test_file}
 #-----------------------------------------------------------
 # Run the ICEPACK model for the restart simulation
 
+echo "ice_ic         = './restart/${fname:t}'" >> ${ICE_CASEDIR}/casescripts/test_nml.restart2
+echo "npt            = $new_npt" >> ${ICE_CASEDIR}/casescripts/test_nml.restart2
 ${ICE_CASEDIR}/casescripts/parse_namelist.sh icepack_in ${ICE_CASEDIR}/casescripts/test_nml.restart2
 cp icepack_in icepack_in.2
 


### PR DESCRIPTION
Modify the restart test script to automatically calculate the restart file date-time group and the number of timesteps, instead of having them hard-coded
Developer(s): Matt Turner
Are the code changes bit for bit, different at roundoff level, or more substantial?  No effect
Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately? (Y/N) N
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/Icepack/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:

- This resolves the issue of the BGC restart run not being able to find the restart file.