### PR TITLE
No error when creating directories

### DIFF
--- a/configuration/scripts/tests/test_restart.script
+++ b/configuration/scripts/tests/test_restart.script
@@ -22,10 +22,10 @@ if ( -d ${ICE_RUNDIR}/restart_baseline ) then
   rm -rf ${ICE_RUNDIR}/restart_baseline
 endif
 mv ${ICE_RUNDIR}/restart ${ICE_RUNDIR}/restart_baseline
-mkdir ${ICE_RUNDIR}/diags_baseline
+mkdir -p ${ICE_RUNDIR}/diags_baseline
 mv ${ICE_RUNDIR}/ice_diag.* ${ICE_RUNDIR}/diags_baseline/
 
-mkdir ${ICE_RUNDIR}/restart
+mkdir -p ${ICE_RUNDIR}/restart
 # Determine the restart file to use
 set numfiles=`ls ${ICE_RUNDIR}/restart_baseline/iced.* | wc -l`
 @ halffiles = $numfiles / 2


### PR DESCRIPTION
Test scripts no longer print errors if a directory already exists.  This resolves https://github.com/CICE-Consortium/Icepack/issues/59

Developer(s): Matt Turner
Are the code changes bit for bit, different at roundoff level, or more substantial? N/A
Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately? (Y/N) N
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/Icepack/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:
