### PR TITLE
Codecleanup5

### DIFF
--- a/columnphysics/icepack_algae.F90
+++ b/columnphysics/icepack_algae.F90
@@ -957,7 +957,8 @@
          Ng_to_mmol =0.0140067_dbl_kind , & ! (g/mmol) Nitrogen
          f_s = c1 , &  ! fracton of sites available for saturation
          f_a = c1 , &  ! fraction of collector available for attachment
-         f_v = 0.7854  ! fraction of algal coverage on area availabel for attachment 4(pi r^2)/(4r)^2  [Johnson et al, 1995, water res. research]
+         f_v = 0.7854  ! fraction of algal coverage on area availabel for attachment
+                       ! 4(pi r^2)/(4r)^2  [Johnson et al, 1995, water res. research]
           
       integer, parameter :: &
          nt_zfswin = 1    ! for interpolation of short wave to bgrid
@@ -1127,6 +1128,7 @@
       do k = 1,nblyr+1
          zfswin(k) = trtmp(nt_zfswin+k-1)
       enddo
+
       !-----------------------------------------------------------------
       ! Initialze Biology  
       !----------------------------------------------------------------- 
@@ -1513,7 +1515,7 @@
          Iavg_loc           ! bottom layer attenuated Fswthru (W/m^2)
 
       real (kind=dbl_kind), dimension(n_algae) :: &
-         L_lim    , &  ! overall light limitation 
+         L_lim    , &  ! overall light limitation
          Nit_lim  , &  ! overall nitrate limitation
          Am_lim   , &  ! overall ammonium limitation
          N_lim    , &  ! overall nitrogen species limitation
@@ -1707,10 +1709,10 @@
              DICin(k)= ltrcrn(nlt_bgc_DIC(k))
          enddo
        endif
-       if (tr_bgc_Am)        Amin     = ltrcrn(nlt_bgc_Am)
-       if (tr_bgc_Sil)       Silin    = ltrcrn(nlt_bgc_Sil)
+       if (tr_bgc_Am)  Amin     = ltrcrn(nlt_bgc_Am)
+       if (tr_bgc_Sil) Silin    = ltrcrn(nlt_bgc_Sil)
        if (tr_bgc_DMS) then
-        !       DMSPpin  = ltrcrn(nlt_bgc_DMSPp)
+       !      DMSPpin  = ltrcrn(nlt_bgc_DMSPp)
              DMSPdin  = ltrcrn(nlt_bgc_DMSPd)
              DMSin    = ltrcrn(nlt_bgc_DMS) 
        endif
@@ -1762,11 +1764,10 @@
 
        do k = 1, n_algae
           ! With light inhibition ! Maybe include light inhibition for diatoms but phaeocystis
-
-           L_lim = (c1 - exp(-alpha2max_low(k)*Iavg_loc)) * exp(-beta2max(k)*Iavg_loc)
+          L_lim = (c1 - exp(-alpha2max_low(k)*Iavg_loc)) * exp(-beta2max(k)*Iavg_loc)
 
           ! Without light inhibition
-          !L_lim(k) = (c1 - exp(-alpha2max_low(k)*Iavg_loc)) 
+          ! L_lim(k) = (c1 - exp(-alpha2max_low(k)*Iavg_loc))
 
       !-----------------------------------------------------------------------
       ! Nutrient limitation
@@ -1864,7 +1865,8 @@
 
           resp(k)   = fr_resp  * grow_N(k)  
           graze(k)  = fr_graze(k) * grow_N(k)
-          mort(k)   = min(max_loss * Nin(k)/dt, mort_pre(k)* exp(mort_Tdep(k)*dTemp) * Nin(k) / secday)
+          mort(k)   = min(max_loss * Nin(k)/dt, &
+                          mort_pre(k)*exp(mort_Tdep(k)*dTemp) * Nin(k)/secday)
  
         ! history variables
           grow_alg(k) = grow_N(k)
@@ -1875,8 +1877,8 @@
           N_r_g  = graze(k)  * dt 
           N_r_r  = resp(k)   * dt
           N_r_mo = mort(k)   * dt
-          N_s(k)    = (c1- fr_resp - fr_graze(k)) * grow_N(k) *dt   !N_s_p
-          N_r(k)    = mort(k) * dt                                  !N_r_g  + N_r_mo + N_r_r 
+          N_s(k)    = (c1- fr_resp - fr_graze(k)) * grow_N(k) *dt ! N_s_p
+          N_r(k)    = mort(k) * dt                                ! N_r_g + N_r_mo + N_r_r
 
           graze_N   = graze_N + graze(k)
           graze_C   = graze_C + R_C2N(k)*graze(k)
@@ -1890,35 +1892,35 @@
       ! Ammonium source: algal grazing, respiration, and mortality
       !--------------------------------------------------------------------
 
-          Am_s_e  = graze_N*(c1-fr_graze_s)*fr_graze_e*dt
-          Am_s_mo = mort_N*fr_mort2min*dt
-          Am_s_r  = resp_N*dt
-          Am_s    = Am_s_r + Am_s_e + Am_s_mo
+      Am_s_e  = graze_N*(c1-fr_graze_s)*fr_graze_e*dt
+      Am_s_mo = mort_N*fr_mort2min*dt
+      Am_s_r  = resp_N*dt
+      Am_s    = Am_s_r + Am_s_e + Am_s_mo
 
       !--------------------------------------------------------------------
       ! Nutrient net loss terms: algal uptake
       !--------------------------------------------------------------------
         
-       do k = 1, n_algae
-          Am_r_p  = U_Am(k)   * dt
-          Am_r    = Am_r + Am_r_p 
-          Nit_r_p = U_Nit(k)  * dt                
-          Nit_r   = Nit_r + Nit_r_p 
-          Sil_r_p = U_Sil(k) * dt
-          Sil_r   = Sil_r + Sil_r_p 
-          Fe_r_p  = U_Fe (k) * dt
-          Fed_tot_r = Fed_tot_r + Fe_r_p  
-          exude_C = exude_C + k_exude(k)* R_C2N(k)*Nin(k) / secday 
-       enddo
+      do k = 1, n_algae
+         Am_r_p  = U_Am(k)   * dt
+         Am_r    = Am_r + Am_r_p
+         Nit_r_p = U_Nit(k)  * dt
+         Nit_r   = Nit_r + Nit_r_p
+         Sil_r_p = U_Sil(k) * dt
+         Sil_r   = Sil_r + Sil_r_p
+         Fe_r_p  = U_Fe (k) * dt
+         Fed_tot_r = Fed_tot_r + Fe_r_p
+         exude_C = exude_C + k_exude(k)* R_C2N(k)*Nin(k) / secday
+      enddo
 
       !--------------------------------------------------------------------
       ! nitrification
       !--------------------------------------------------------------------
 
-       nitrif  = k_nitrif /secday * Amin 
-       Am_r = Am_r +  nitrif*dt
-       Nit_s_n = nitrif * dt  !source from NH4
-       Nit_s   = Nit_s_n  
+      nitrif  = k_nitrif /secday * Amin
+      Am_r    = Am_r +  nitrif*dt
+      Nit_s_n = nitrif * dt  ! source from NH4
+      Nit_s   = Nit_s_n
 
       !--------------------------------------------------------------------
       ! PON:  currently using PON to shadow nitrate
@@ -1929,48 +1931,48 @@
       ! of DON (Zoo_s_b). 
       !--------------------------------------------------------------------
 
-       if (tr_bgc_Am) then
+      if (tr_bgc_Am) then
          Zoo_s_a = graze_N*(c1-fr_graze_e)*(c1-fr_graze_s) *dt
          Zoo_s_s = graze_N*fr_graze_s*dt
          Zoo_s_m = mort_N*dt  -  Am_s_mo
-       else
+      else
          Zoo_s_a = graze_N*dt*(c1-fr_graze_s)
          Zoo_s_s = graze_N*fr_graze_s*dt
          Zoo_s_m = mort_N*dt 
-       endif
+      endif
 
-         Zoo_s_b = c0
+      Zoo_s_b = c0
 
       !--------------------------------------------------------------------
       ! DON (n_don = 1)
       ! Proteins   
       !--------------------------------------------------------------------
 
-       DON_r(:) = c0
-       DON_s(:) = c0
+      DON_r(:) = c0
+      DON_s(:) = c0
 
-       if (tr_bgc_DON) then
-       do n = 1, n_don   
-          DON_r(n) =  kn_bac(n)/secday * DONin(n) * dt
-          DON_s(n) =  graze_N*f_don(n)*fr_graze_s * dt 
-          Zoo_s_s = Zoo_s_s - DON_s(n)
-          Zoo_s_b = Zoo_s_b + DON_r(n)*(c1-f_don_Am(n))
-          !Am_s = Am_s + DON_r(n)*f_don_Am(n)
+      if (tr_bgc_DON) then
+      do n = 1, n_don
+         DON_r(n) = kn_bac(n)/secday * DONin(n) * dt
+         DON_s(n) = graze_N*f_don(n)*fr_graze_s * dt
+         Zoo_s_s  = Zoo_s_s - DON_s(n)
+         Zoo_s_b  = Zoo_s_b + DON_r(n)*(c1-f_don_Am(n))
+         !Am_s     = Am_s + DON_r(n)*f_don_Am(n)
       enddo
       endif
      
-       Zoo = Zoo_s_a + Zoo_s_s + Zoo_s_m + Zoo_s_b
+      Zoo = Zoo_s_a + Zoo_s_s + Zoo_s_m + Zoo_s_b
 
       !--------------------------------------------------------------------
       ! DOC
       ! polysaccharids, lipids
       !--------------------------------------------------------------------
 
-       do n = 1, n_doc   
+      do n = 1, n_doc
           
-          DOC_r(n) =  k_bac(n)/secday * DOCin(n) * dt
-          DOC_s(n) =  f_doc(n)*(fr_graze_s *graze_C + mort_C)*dt &
-                      + f_exude(n)*exude_C
+         DOC_r(n) = k_bac(n)/secday * DOCin(n) * dt
+         DOC_s(n) = f_doc(n)*(fr_graze_s *graze_C + mort_C)*dt &
+                  + f_exude(n)*exude_C
       enddo
 
       !--------------------------------------------------------------------
@@ -1988,27 +1990,27 @@
       if (tr_bgc_C .and. tr_bgc_Fe) then
         if (DOCin(1) > c0) then 
         if (Fed_tot/DOCin(1) > max_dfe_doc1) then             
-          do n = 1,n_fed                                    ! low saccharid:dFe ratio leads to 
-             Fed_r_l(n)  = Fedin(n)/t_iron_conv*dt/secday   ! loss of bioavailable Fe to particulate fraction
+          do n = 1,n_fed                                  ! low saccharid:dFe ratio leads to
+             Fed_r_l(n)  = Fedin(n)/t_iron_conv*dt/secday ! loss of bioavailable Fe to particulate fraction
              Fep_tot_s   = Fep_tot_s + Fed_r_l(n)
-             Fed_r(n)    = Fed_r_l(n)                        ! removal due to particulate scavenging 
+             Fed_r(n)    = Fed_r_l(n)                     ! removal due to particulate scavenging
           enddo
           do n = 1,n_fep
-             Fep_s(n) = rFep(n)* Fep_tot_s                  ! source from dissolved Fe 
+             Fep_s(n) = rFep(n)* Fep_tot_s                ! source from dissolved Fe
           enddo
         elseif (Fed_tot/DOCin(1) < max_dfe_doc1) then  
-          do n = 1,n_fep                                    ! high saccharid:dFe ratio leads to 
-             Fep_r(n)  = Fepin(n)/t_iron_conv*dt/secday     ! gain of bioavailable Fe from particulate fraction
+          do n = 1,n_fep                                  ! high saccharid:dFe ratio leads to
+             Fep_r(n)  = Fepin(n)/t_iron_conv*dt/secday   ! gain of bioavailable Fe from particulate fraction
              Fed_tot_s = Fed_tot_s + Fep_r(n)
           enddo  
           do n = 1,n_fed
-             Fed_s(n) = Fed_s(n) + rFed(n)* Fed_tot_s       ! source from particulate Fe
+             Fed_s(n) = Fed_s(n) + rFed(n)* Fed_tot_s     ! source from particulate Fe
           enddo    
         endif
         endif !Docin(1) > c0
       elseif (tr_bgc_Fe) then
         do n = 1,n_fed
-           Fed_r(n) = Fed_r(n) + rFed(n)*Fed_tot_r          ! scavenging + uptake
+           Fed_r(n) = Fed_r(n) + rFed(n)*Fed_tot_r        ! scavenging + uptake
         enddo 
 
       ! source from algal mortality/grazing and fraction of remineralized nitrogen that does 
@@ -2034,69 +2036,68 @@
       !                      *fr_graze*grow_N + fr_mort2min*mort)*dt
       !             - [\DMSPd]/t_sk_conv*dt
       !--------------------------------------------------------------------
-       do k = 1,n_algae
-          DMSPd_s_r = fr_resp_s  * R_S2N(k) * resp(k)   * dt  !respiration fraction to DMSPd
-          DMSPd_s_mo= fr_mort2min * R_S2N(k)* mort(k)   * dt  !mortality and extracellular excretion
-
-          DMSPd_s = DMSPd_s + DMSPd_s_r + DMSPd_s_mo 
-       enddo
-       DMSPd_r = (c1/t_sk_conv) * (c1/secday)  * (DMSPdin) * dt
+      do k = 1,n_algae
+         DMSPd_s_r = fr_resp_s  * R_S2N(k) * resp(k)   * dt  !respiration fraction to DMSPd
+         DMSPd_s_mo= fr_mort2min * R_S2N(k)* mort(k)   * dt  !mortality and extracellular excretion
+         DMSPd_s = DMSPd_s + DMSPd_s_r + DMSPd_s_mo 
+      enddo
+      DMSPd_r = (c1/t_sk_conv) * (c1/secday)  * (DMSPdin) * dt
 
       !--------------------------------------------------------------------
       ! DMS reaction term + DMSPd loss term 
       ! DMS_react = ([\DMSPd]*y_sk_DMS/t_sk_conv - c1/t_sk_ox *[\DMS])*dt
       !--------------------------------------------------------------------
 
-       DMS_s_c = y_sk_DMS * DMSPd_r 
-       DMS_r_o = DMSin * dt / (t_sk_ox * secday)
-       DMS_s   = DMS_s_c
-       DMS_r   = DMS_r_o
+      DMS_s_c = y_sk_DMS * DMSPd_r
+      DMS_r_o = DMSin * dt / (t_sk_ox * secday)
+      DMS_s   = DMS_s_c
+      DMS_r   = DMS_r_o
 
       !-----------------------------------------------------------------------
       ! Load reaction array
       !-----------------------------------------------------------------------
 
-       dN = c0
-       do k = 1,n_algae
-              reactb(nlt_bgc_N(k))  = N_s(k) - N_r(k)
-              dN = dN + reactb(nlt_bgc_N(k))
-       enddo
-       if (tr_bgc_C) then
-        ! do k = 1,n_algae
-        !      reactb(nlt_bgc_C(k))  = R_C2N(k)*reactb(nlt_bgc_N(k))
-        ! enddo
+      dN = c0
+      do k = 1,n_algae
+         reactb(nlt_bgc_N(k))  = N_s(k) - N_r(k)
+         dN = dN + reactb(nlt_bgc_N(k))
+      enddo
+      if (tr_bgc_C) then
+       ! do k = 1,n_algae
+       !      reactb(nlt_bgc_C(k))  = R_C2N(k)*reactb(nlt_bgc_N(k))
+       ! enddo
          do k = 1,n_doc
-              reactb(nlt_bgc_DOC(k))= DOC_s(k) - DOC_r(k)  
+            reactb(nlt_bgc_DOC(k))= DOC_s(k) - DOC_r(k)
          enddo
-       endif
-              reactb(nlt_bgc_Nit)   = Nit_s   - Nit_r
-              dN = dN + reactb(nlt_bgc_Nit)
-       if (tr_bgc_Am)  then
-              reactb(nlt_bgc_Am)    = Am_s    - Am_r
-              dN = dN + reactb(nlt_bgc_Am)
-       endif
-       if (tr_bgc_Sil) then
-              reactb(nlt_bgc_Sil)   =  - Sil_r
-       endif
-       if (tr_bgc_DON) then
+      endif
+            reactb(nlt_bgc_Nit)   = Nit_s   - Nit_r
+            dN = dN + reactb(nlt_bgc_Nit)
+      if (tr_bgc_Am)  then
+            reactb(nlt_bgc_Am)    = Am_s    - Am_r
+            dN = dN + reactb(nlt_bgc_Am)
+      endif
+      if (tr_bgc_Sil) then
+            reactb(nlt_bgc_Sil)   =  - Sil_r
+      endif
+      if (tr_bgc_DON) then
          do k = 1,n_don
-              reactb(nlt_bgc_DON(k))= DON_s(k) - DON_r(k)  
-              dN = dN + reactb(nlt_bgc_DON(k))
+            reactb(nlt_bgc_DON(k))= DON_s(k) - DON_r(k)  
+            dN = dN + reactb(nlt_bgc_DON(k))
          enddo
-       endif 
-       if (tr_bgc_Fe ) then
-        do k = 1,n_fed
-              reactb(nlt_bgc_Fed(k))= Fed_s (k) - Fed_r (k) 
-        enddo
-        do k = 1,n_fep
-              reactb(nlt_bgc_Fep(k))= Fep_s (k) - Fep_r (k) 
-        enddo
-       endif 
-       if (tr_bgc_DMS) then
-              reactb(nlt_bgc_DMSPd) = DMSPd_s - DMSPd_r
-              reactb(nlt_bgc_DMS)   = DMS_s   - DMS_r
-       endif
-       Nerror = dN + Zoo
+      endif
+      if (tr_bgc_Fe ) then
+         do k = 1,n_fed
+            reactb(nlt_bgc_Fed(k))= Fed_s (k) - Fed_r (k) 
+         enddo
+         do k = 1,n_fep
+            reactb(nlt_bgc_Fep(k))= Fep_s (k) - Fep_r (k) 
+         enddo
+      endif
+      if (tr_bgc_DMS) then
+         reactb(nlt_bgc_DMSPd) = DMSPd_s - DMSPd_r
+         reactb(nlt_bgc_DMS)   = DMS_s   - DMS_r
+      endif
+      Nerror = dN + Zoo
       ! if (abs(Nerror) > max(reactb(:))*1.0e-5) then
       !      conserve_N = .false.
       !      write(warnstr,*) subname, 'Conservation error!'
@@ -2198,14 +2199,13 @@
 !
 ! July, 2014 by N. Jeffery
 !
-      subroutine compute_FCT_matrix &
-                                     (C_in, sbdiag, dt,  nblyr,   &
-                                      diag, spdiag, rhs, bgrid,   &
-                                      i_grid, darcyV, dhtop, dhbot,&
-                                      iphin_N, iDin, hbri_old,    &
-                                      atm_add, bphin_N,           &
-                                      C_top, C_bot, Qbot, Qtop,   &
-                                      Sink_bot, Sink_top,         &
+      subroutine compute_FCT_matrix  (C_in, sbdiag, dt,  nblyr,     &
+                                      diag, spdiag, rhs, bgrid,     &
+                                      i_grid, darcyV, dhtop, dhbot, &
+                                      iphin_N, iDin, hbri_old,      &
+                                      atm_add, bphin_N,             &
+                                      C_top, C_bot, Qbot, Qtop,     &
+                                      Sink_bot, Sink_top,           &
                                       D_sbdiag, D_spdiag, ML)
 
       integer (kind=int_kind), intent(in) :: &
@@ -2279,16 +2279,16 @@
 !  spdiag(j) == (j,j+1) solve for j = 1:nblyr otherwise 0
 !  sbdiag(j) == (j,j-1) solve for j = 2:nblyr+1 otherwise 0
 !---------------------------------------------------------------------
-     kvector1(:) = c0
-     kvector1(1) = c1 
-     kvectorn1(:) = c1
-     kvectorn1(1) = c0 
+      kvector1(:) = c0
+      kvector1(1) = c1
+      kvectorn1(:) = c1
+      kvectorn1(1) = c0
 
-     zspace = c1/real(nblyr,kind=dbl_kind) 
-     Qbot = c0
-     Qtop = c0
-     Sink_bot = c0
-     Sink_top = c0
+      zspace = c1/real(nblyr,kind=dbl_kind)
+      Qbot = c0
+      Qtop = c0
+      Sink_bot = c0
+      Sink_top = c0
 
 ! compute the lumped mass matrix
 
@@ -2296,7 +2296,7 @@
       ML(1) = zspace/c2
       ML(nblyr+1) = zspace/c2
 
-! compute matrix K: K_diag , K_sbdiag, K_spdiag 
+! compute matrix K: K_diag , K_sbdiag, K_spdiag
 ! compute matrix S: S_diag, S_sbdiag, S_spdiag
 
       K_diag(:) = c0
@@ -2309,7 +2309,6 @@
       S_spdiag(:) = c0
       S_sbdiag(:) = c0
       iDin_phi(:) = c0
-      
 
       iDin_phi(1) = c0  !element 1
       iDin_phi(nblyr+1) = iDin(nblyr+1)/iphin_N(nblyr+1)  !outside ice at bottom
@@ -2317,7 +2316,7 @@
 
       vel = (bgrid(2)*dhbot - (bgrid(2)-c1)*dhtop)/dt+darcyV/bphin_N(2)
       K_diag(1) = p5*vel/hbri_old   
-      dphi_dx = (iphin_N(nblyr+1) - iphin_N(nblyr))/(zspace)  
+      dphi_dx = (iphin_N(nblyr+1) - iphin_N(nblyr))/(zspace)
       vel = (bgrid(nblyr+1)*dhbot - (bgrid(nblyr+1)-c1)*dhtop)/dt  +darcyV/bphin_N(nblyr+1)  
       vel = vel/hbri_old   
       vel2 = (dhbot/hbri_old/dt +darcyV/hbri_old) 
@@ -2343,7 +2342,7 @@
          S_sbdiag(k+1) = iDin_phi(k)/zspace
       enddo
 
-      !k = nblyr
+      ! k = nblyr
 
       vel = (bgrid(nblyr+1)*dhbot - (bgrid(nblyr+1)-c1)*dhtop)/dt+darcyV/bphin_N(nblyr+1)
       dphi_dx =  (iphin_N(nblyr+1) - iphin_N(nblyr))/(zspace)
@@ -2403,8 +2402,7 @@
 !
 ! July, 2014 by N. Jeffery
 !
-      subroutine compute_FCT_corr &
-                                     (C_in, C_low, dt,  nblyr, &
+      subroutine compute_FCT_corr    (C_in, C_low, dt,  nblyr, &
                                       D_sbdiag, D_spdiag, ML)
 
       integer (kind=int_kind), intent(in) :: &
@@ -2450,7 +2448,7 @@
 !  sbdiag(j) == (j,j-1) solve for j = 2:nblyr+1 otherwise 0
 !---------------------------------------------------------------------
 
-     zspace = c1/real(nblyr,kind=dbl_kind) 
+      zspace = c1/real(nblyr,kind=dbl_kind) 
 
 ! compute the mass matrix
 
@@ -2466,16 +2464,16 @@
       F_sbdiag(:) = c0
 
       do k = 1, nblyr 
-           F_spdiag(k) = M_spdiag(k)*(C_low(k)-C_in(k) - C_low(k+1)+ C_in(k+1))/dt &
-                       + D_spdiag(k)*(C_low(k)-C_low(k+1))
-           F_sbdiag(k+1) =  M_sbdiag(k+1)*(C_low(k+1)-C_in(k+1) - C_low(k)+ C_in(k))/dt &
+         F_spdiag(k) = M_spdiag(k)*(C_low(k)-C_in(k) - C_low(k+1)+ C_in(k+1))/dt &
+                     + D_spdiag(k)*(C_low(k)-C_low(k+1))
+         F_sbdiag(k+1) =  M_sbdiag(k+1)*(C_low(k+1)-C_in(k+1) - C_low(k)+ C_in(k))/dt &
                        + D_sbdiag(k+1)*(C_low(k+1)-C_low(k))
 
-           if (F_spdiag(k)*(C_low(k) - C_low(k+1)) > c0) F_spdiag(k) = c0
-           if (F_sbdiag(k+1)*(C_low(k+1) - C_low(k)) > c0) F_sbdiag(k+1) = c0
-     enddo
+         if (F_spdiag(k)*(C_low(k) - C_low(k+1)) > c0) F_spdiag(k) = c0
+         if (F_sbdiag(k+1)*(C_low(k+1) - C_low(k)) > c0) F_sbdiag(k+1) = c0
+      enddo
 
-    if (maxval(abs(F_spdiag)) > c0) then
+      if (maxval(abs(F_spdiag)) > c0) then
 
 ! compute the weighting factors: a_spdiag, a_sbdiag
 
@@ -2512,19 +2510,19 @@
 
 !compute F_diag:
 
-     F_diag(1) = a_spdiag(1)*F_spdiag(1)
-     F_diag(nblyr+1) = a_sbdiag(nblyr+1)* F_sbdiag(nblyr+1) 
-     C_low(1) = C_low(1) + dt*F_diag(1)/ML(1)
-     C_low(nblyr+1) = C_low(nblyr+1) + dt*F_diag(nblyr+1)/ML(nblyr+1)
+      F_diag(1) = a_spdiag(1)*F_spdiag(1)
+      F_diag(nblyr+1) = a_sbdiag(nblyr+1)* F_sbdiag(nblyr+1)
+      C_low(1) = C_low(1) + dt*F_diag(1)/ML(1)
+      C_low(nblyr+1) = C_low(nblyr+1) + dt*F_diag(nblyr+1)/ML(nblyr+1)
 
-     do k = 2,nblyr
+      do k = 2,nblyr
          F_diag(k) = a_spdiag(k)*F_spdiag(k) + a_sbdiag(k)*F_sbdiag(k)
          C_low(k) = C_low(k) + dt*F_diag(k)/ML(k)
-     enddo
+      enddo
       
-     endif  !F_spdiag is nonzero
+      endif  !F_spdiag is nonzero
 
-     end subroutine compute_FCT_corr
+      end subroutine compute_FCT_corr
   
 !=======================================================================
 !
@@ -2540,15 +2538,13 @@
       integer (kind=int_kind), intent(in) :: &
          nmat            ! matrix dimension
 
-      real (kind=dbl_kind), dimension (nmat), &
-           intent(in) :: &
+      real (kind=dbl_kind), dimension (nmat), intent(in) :: &
          sbdiag      , & ! sub-diagonal matrix elements
          diag        , & ! diagonal matrix elements
          spdiag      , & ! super-diagonal matrix elements
          rhs             ! rhs of tri-diagonal matrix eqn.
 
-      real (kind=dbl_kind), dimension (nmat), &
-           intent(inout) :: &
+      real (kind=dbl_kind), dimension (nmat), intent(inout) :: &
          xout            ! solution vector
 
       ! local variables     
@@ -2564,18 +2560,17 @@
 
       character(len=*),parameter :: subname='(tridiag_solverz)'
 
-         wbeta = diag(1)
-         xout(1) = rhs(1) / wbeta
+      wbeta = diag(1)
+      xout(1) = rhs(1) / wbeta
 
       do k = 2, nmat
-            wgamma(k) = spdiag(k-1) / wbeta
-            wbeta = diag(k) - sbdiag(k)*wgamma(k)
-            xout(k) = (rhs(k) - sbdiag(k)*xout(k-1)) &
-                         / wbeta
+         wgamma(k) = spdiag(k-1) / wbeta
+         wbeta = diag(k) - sbdiag(k)*wgamma(k)
+         xout(k) = (rhs(k) - sbdiag(k)*xout(k-1)) / wbeta
       enddo                     ! k
 
       do k = nmat-1, 1, -1
-            xout(k) = xout(k) - wgamma(k+1)*xout(k+1)
+         xout(k) = xout(k) - wgamma(k+1)*xout(k+1)
       enddo                     ! k
 
       end subroutine tridiag_solverz
@@ -2584,11 +2579,10 @@
 !
 ! authors     Nicole Jeffery, LANL
 
-      subroutine check_conservation_FCT &
-                                     (C_init, C_new, C_low, S_top, &
-                                      S_bot, L_bot, L_top, dt,     &
-                                      fluxbio, nblyr, &
-                                      source) 
+      subroutine check_conservation_FCT (C_init, C_new, C_low, S_top, &
+                                         S_bot, L_bot, L_top, dt,     &
+                                         fluxbio, nblyr, &
+                                         source) 
 
       integer (kind=int_kind), intent(in) :: &
          nblyr             ! number of bio layers
@@ -2625,52 +2619,52 @@
 
       character(len=*),parameter :: subname='(check_conservation_FCT)'
 
-         zspace = c1/real(nblyr,kind=dbl_kind)
+      zspace = c1/real(nblyr,kind=dbl_kind)
 
-     !-------------------------------------
-     !  Ocean flux: positive into the ocean
-     !-------------------------------------    
-         C_init_tot = (C_init(1) + C_init(nblyr+1))*zspace*p5
-         C_new_tot = (C_new(1) + C_new(nblyr+1))*zspace*p5
-         C_low(1) = C_new(1)
-         C_low(nblyr+1) = C_new(nblyr+1)
+      !-------------------------------------
+      !  Ocean flux: positive into the ocean
+      !-------------------------------------
+      C_init_tot = (C_init(1) + C_init(nblyr+1))*zspace*p5
+      C_new_tot = (C_new(1) + C_new(nblyr+1))*zspace*p5
+      C_low(1) = C_new(1)
+      C_low(nblyr+1) = C_new(nblyr+1)
 
-         do k = 2, nblyr
-            C_init_tot = C_init_tot + C_init(k)*zspace
-            C_new_tot = C_new_tot + C_new(k)*zspace
-            C_low(k) = C_new(k)
-         enddo
+      do k = 2, nblyr
+         C_init_tot = C_init_tot + C_init(k)*zspace
+         C_new_tot = C_new_tot + C_new(k)*zspace
+         C_low(k) = C_new(k)
+      enddo
 
-         accuracy = 1.0e-14_dbl_kind*max(c1, C_init_tot, C_new_tot)  
-         fluxbio = (C_init_tot - C_new_tot + source)/dt
-         diff_dt =C_new_tot - C_init_tot - (S_top+S_bot+L_bot*C_new(nblyr+1)+L_top*C_new(1))*dt
+      accuracy = 1.0e-14_dbl_kind*max(c1, C_init_tot, C_new_tot)
+      fluxbio = (C_init_tot - C_new_tot + source)/dt
+      diff_dt =C_new_tot - C_init_tot - (S_top+S_bot+L_bot*C_new(nblyr+1)+L_top*C_new(1))*dt
 
-         if (minval(C_low) < c0) then 
-           write(warnstr,*) subname, 'Positivity of zbgc low order solution failed: C_low:',C_low
-           call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
-         endif
+      if (minval(C_low) < c0) then
+         write(warnstr,*) subname, 'Positivity of zbgc low order solution failed: C_low:',C_low
+         call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
+      endif
            
-         if (abs(diff_dt) > accuracy ) then
-           call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
-           write(warnstr,*) subname, 'Conservation of zbgc low order solution failed: diff_dt:',&
+      if (abs(diff_dt) > accuracy ) then
+         call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
+         write(warnstr,*) subname, 'Conservation of zbgc low order solution failed: diff_dt:',&
                         diff_dt
-           write(warnstr,*) subname, 'Total initial tracer', C_init_tot
-           write(warnstr,*) subname, 'Total final1  tracer', C_new_tot
-           write(warnstr,*) subname, 'bottom final tracer', C_new(nblyr+1)
-           write(warnstr,*) subname, 'top final tracer', C_new(1)
-           write(warnstr,*) subname, 'Near bottom final tracer', C_new(nblyr)
-           write(warnstr,*) subname, 'Near top final tracer', C_new(2)
-           write(warnstr,*) subname, 'Top flux*dt into ice:', S_top*dt
-           write(warnstr,*) subname, 'Bottom flux*dt into ice:', S_bot*dt
-           write(warnstr,*) subname, 'Remaining bot flux*dt into ice:', L_bot*C_new(nblyr+1)*dt
-           write(warnstr,*) subname, 'S_bot*dt + L_bot*C_new(nblyr+1)*dt'
-           write(warnstr,*) subname,  S_bot*dt + L_bot*C_new(nblyr+1)*dt
-           write(warnstr,*) subname, 'fluxbio*dt:', fluxbio*dt
-           write(warnstr,*) subname, 'fluxbio:', fluxbio
-           write(warnstr,*) subname, 'Remaining top flux*dt into ice:', L_top*C_new(1)*dt
-         endif
+         write(warnstr,*) subname, 'Total initial tracer', C_init_tot
+         write(warnstr,*) subname, 'Total final1  tracer', C_new_tot
+         write(warnstr,*) subname, 'bottom final tracer', C_new(nblyr+1)
+         write(warnstr,*) subname, 'top final tracer', C_new(1)
+         write(warnstr,*) subname, 'Near bottom final tracer', C_new(nblyr)
+         write(warnstr,*) subname, 'Near top final tracer', C_new(2)
+         write(warnstr,*) subname, 'Top flux*dt into ice:', S_top*dt
+         write(warnstr,*) subname, 'Bottom flux*dt into ice:', S_bot*dt
+         write(warnstr,*) subname, 'Remaining bot flux*dt into ice:', L_bot*C_new(nblyr+1)*dt
+         write(warnstr,*) subname, 'S_bot*dt + L_bot*C_new(nblyr+1)*dt'
+         write(warnstr,*) subname,  S_bot*dt + L_bot*C_new(nblyr+1)*dt
+         write(warnstr,*) subname, 'fluxbio*dt:', fluxbio*dt
+         write(warnstr,*) subname, 'fluxbio:', fluxbio
+         write(warnstr,*) subname, 'Remaining top flux*dt into ice:', L_top*C_new(1)*dt
+      endif
          
-     end subroutine check_conservation_FCT
+      end subroutine check_conservation_FCT
 
 !=======================================================================
 

--- a/columnphysics/icepack_intfc.F90
+++ b/columnphysics/icepack_intfc.F90
@@ -71,6 +71,8 @@
       use icepack_atmo , only: icepack_atm_boundary
       use icepack_ocean, only: icepack_ocn_mixed_layer
 
+      use icepack_orbital       , only: icepack_init_orbit
+
       use icepack_therm_vertical, only: icepack_step_therm1
       use icepack_therm_itd     , only: icepack_step_therm2
       use icepack_therm_shared  , only: icepack_ice_temperature
@@ -80,8 +82,6 @@
       use icepack_therm_shared  , only: icepack_enthalpy_snow
       use icepack_therm_shared  , only: icepack_init_thermo
       use icepack_therm_shared  , only: icepack_init_trcr
-
-      use icepack_orbital , only: icepack_init_orbit
 
       use icepack_warnings, only: icepack_warnings_clear
       use icepack_warnings, only: icepack_warnings_getall

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -288,66 +288,54 @@
 
       ! topo ponds
       real (kind=dbl_kind), public :: &
-         hp1       = 0.01_dbl_kind ! critical pond lid thickness for topo ponds
+         hp1       = 0.01_dbl_kind    ! critical pond lid thickness for topo ponds
 
 !-----------------------------------------------------------------------
 ! Parameters for biogeochemistry
 !-----------------------------------------------------------------------
 
       character(char_len), public :: &          
-         bgc_flux_type      ! type of ocean-ice piston velocity 
-                            ! 'constant', 'Jin2006' 
+      ! skl biology parameters
+         bgc_flux_type = 'Jin2006'  ! type of ocean-ice poston velocity (or 'constant')
 
       logical (kind=log_kind), public :: &
-         z_tracers,      & ! if .true., bgc or aerosol tracers are vertically resolved
-         scale_bgc,      & ! if .true., initialize bgc tracers proportionally with salinity
-         solve_zbgc,     & ! if .true., solve vertical biochemistry portion of code
-         dEdd_algae        ! if .true., algal absorption of shortwave is computed in the
-
-      logical (kind=log_kind), public :: & 
-         skl_bgc         ! if true, solve skeletal biochemistry
+         z_tracers  = .false.,    & ! if .true., bgc or aerosol tracers are vertically resolved
+         scale_bgc  = .false.,    & ! if .true., initialize bgc tracers proportionally with salinity
+         solve_zbgc = .false.,    & ! if .true., solve vertical biochemistry portion of code
+         dEdd_algae = .false.,    & ! if .true., algal absorption of shortwave is computed in the
+         skl_bgc    = .false.       ! if true, solve skeletal biochemistry
 
       real (kind=dbl_kind), public :: & 
-         grid_o      , & ! for bottom flux        
-         l_sk        , & ! characteristic diffusive scale (zsalinity) (m)
-         phi_snow    , & ! porosity of snow
-         initbio_frac    ! fraction of ocean tracer concentration used to initialize tracer 
-
-      real (kind=dbl_kind), public :: & 
-         grid_oS     , & ! for bottom flux (zsalinity)
-         l_skS           ! 0.02 characteristic skeletal layer thickness (m) (zsalinity)
-
-      real (kind=dbl_kind), public :: &
-         fr_resp           , &   ! fraction of algal growth lost due to respiration        
-         algal_vel         , &   ! 0.5 cm/d(m/s) Lavoie 2005  1.5 cm/day
-         R_dFe2dust        , &   !  g/g (3.5% content) Tagliabue 2009
-         dustFe_sol        , &   ! solubility fraction
-         frazil_scav             ! fraction or multiple of bgc concentrated in frazil ice
-
-      real (kind=dbl_kind), public :: &
-         sk_l      = 0.03_dbl_kind, & ! skeletal layer thickness (m)
-         min_bgc  = 0.01_dbl_kind     ! fraction of ocean bgc concentration in surface melt
-
-      !-----------------------------------------------------------------
-      ! From algal_dyn in icepack_algae.F90
-      !-----------------------------------------------------------------
-
-      real (kind=dbl_kind), public :: &
-         T_max            , & ! maximum temperature (C)
-         fsal             , & ! Salinity limitation (ppt)
-         op_dep_min       , & ! Light attenuates for optical depths exceeding min
-         fr_graze_s       , & ! fraction of grazing spilled or slopped
-         fr_graze_e       , & ! fraction of assimilation excreted 
-         fr_mort2min      , & ! fractionation of mortality to Am
-         fr_dFe           , & ! fraction of remineralized nitrogen (in units of algal iron)
-         k_nitrif         , & ! nitrification rate (1/day)           
-         t_iron_conv      , & ! desorption loss pFe to dFe (day)
-         max_loss         , & ! restrict uptake to % of remaining value 
-         max_dfe_doc1     , & ! max ratio of dFe to saccharides in the ice (nM Fe/muM C)    
-         fr_resp_s        , & ! DMSPd fraction of respiration loss as DMSPd
-         y_sk_DMS         , & ! fraction conversion given high yield
-         t_sk_conv        , & ! Stefels conversion time (d)
-         t_sk_ox              ! DMS oxidation time (d)
+         phi_snow     = p5              , & ! snow porosity
+         grid_o       = c5              , & ! for bottom flux
+         initbio_frac = c1              , & ! fraction of ocean trcr concentration in bio trcrs
+         l_sk         = 7.0_dbl_kind    , & ! characteristic diffusive scale (m)
+         grid_oS      = c5              , & ! for bottom flux
+         l_skS        = 7.0_dbl_kind    , & ! characteristic skeletal layer thickness (m) (zsalinity)
+         algal_vel    = 1.11e-8_dbl_kind, & ! 0.5 cm/d(m/s) Lavoie 2005  1.5 cm/day
+         R_dFe2dust   = 0.035_dbl_kind  , & !  g/g (3.5% content) Tagliabue 2009
+         dustFe_sol   = 0.005_dbl_kind  , & ! solubility fraction
+         frazil_scav  = c1              , & ! fraction or multiple of bgc concentrated in frazil ice
+         sk_l         = 0.03_dbl_kind   , & ! skeletal layer thickness (m)
+         min_bgc      = 0.01_dbl_kind   , & ! fraction of ocean bgc concentration in surface melt
+         T_max        = c0              , & ! maximum temperature (C)
+         fsal         = c1              , & ! Salinity limitation (1)
+         op_dep_min   = p1              , & ! light attenuates for optical depths exceeding min
+         fr_graze_s   = p5              , & ! fraction of grazing spilled or slopped
+         fr_graze_e   = p5              , & ! fraction of assimilation excreted
+         fr_mort2min  = p5              , & ! fractionation of mortality to Am
+         fr_dFe       = 0.3_dbl_kind    , & ! fraction of remineralized nitrogen
+                                            ! (in units of algal iron)
+         k_nitrif     = c0              , & ! nitrification rate (1/day)
+         t_iron_conv  = 3065.0_dbl_kind , & ! desorption loss pFe to dFe (day)
+         max_loss     = 0.9_dbl_kind    , & ! restrict uptake to % of remaining value
+         max_dfe_doc1 = 0.2_dbl_kind    , & ! max ratio of dFe to saccharides in the ice
+                                            ! (nM Fe/muM C)
+         fr_resp      = 0.05_dbl_kind   , & ! fraction of algal growth lost due to respiration
+         fr_resp_s    = 0.75_dbl_kind   , & ! DMSPd fraction of respiration loss as DMSPd
+         y_sk_DMS     = p5              , & ! fraction conversion given high yield
+         t_sk_conv    = 3.0_dbl_kind    , & ! Stefels conversion time (d)
+         t_sk_ox      = 10.0_dbl_kind       ! DMS oxidation time (d)
 
 !=======================================================================
 

--- a/columnphysics/icepack_zbgc.F90
+++ b/columnphysics/icepack_zbgc.F90
@@ -36,10 +36,6 @@
       use icepack_zbgc_shared, only: f_don, kn_bac, f_don_Am, f_doc
       use icepack_zbgc_shared, only: f_exude, k_bac
       use icepack_zbgc_shared, only: tau_ret, tau_rel
-      use icepack_zbgc_shared, only: dictype, algaltype, doctype, dontype
-      use icepack_zbgc_shared, only: fedtype, feptype, zaerotype
-      use icepack_zbgc_shared, only: nitratetype, silicatetype, ammoniumtype
-      use icepack_zbgc_shared, only: humtype, dmspptype, dmspdtype
       use icepack_zbgc_shared, only: R_C2N, R_CHL2N, f_abs_chl, R_C2N_DON
 
       use icepack_warnings, only: warnstr, icepack_warnings_add
@@ -680,30 +676,12 @@
                  alpha2max_low_in, beta2max_in, mu_max_in, fr_graze_in, mort_pre_in, &
                  mort_Tdep_in, k_exude_in, K_Nit_in, K_Am_in, K_sil_in, K_Fe_in, &
                  f_don_in, kn_bac_in, f_don_Am_in, f_doc_in, f_exude_in, k_bac_in, &
-                 algaltype_in, doctype_in, dontype_in, fedtype_in, feptype_in, &
-                 zaerotype_in, dictype_in, grow_Tdep_in, zbgc_frac_init_in, &
+                 grow_Tdep_in, zbgc_frac_init_in, &
                  zbgc_init_frac_in, tau_ret_in, tau_rel_in, bgc_tracer_type_in, &
                  fr_resp_in, algal_vel_in, R_dFe2dust_in, dustFe_sol_in, T_max_in, &
                  op_dep_min_in, fr_graze_s_in, fr_graze_e_in, fr_mort2min_in, fr_dFe_in, &
                  k_nitrif_in, t_iron_conv_in, max_loss_in, max_dfe_doc1_in, &
-                 fr_resp_s_in, y_sk_DMS_in, t_sk_conv_in, t_sk_ox_in, &
-                 fsal_in, nitratetype_in, ammoniumtype_in, silicatetype_in, humtype_in, &
-                 dmspptype_in, dmspdtype_in)
-
-      real (kind=dbl_kind), optional :: dictype_in(:)
-      real (kind=dbl_kind), optional :: algaltype_in(:)
-      real (kind=dbl_kind), optional :: doctype_in(:)
-      real (kind=dbl_kind), optional :: dontype_in(:)
-      real (kind=dbl_kind), optional :: fedtype_in(:)
-      real (kind=dbl_kind), optional :: feptype_in(:)
-      real (kind=dbl_kind), optional :: zaerotype_in(:)
-
-      real (kind=dbl_kind), optional :: nitratetype_in
-      real (kind=dbl_kind), optional :: ammoniumtype_in
-      real (kind=dbl_kind), optional :: silicatetype_in
-      real (kind=dbl_kind), optional :: humtype_in
-      real (kind=dbl_kind), optional :: dmspptype_in
-      real (kind=dbl_kind), optional :: dmspdtype_in
+                 fr_resp_s_in, y_sk_DMS_in, t_sk_conv_in, t_sk_ox_in, fsal_in)
 
       real (kind=dbl_kind), optional :: R_C2N_in(:)        ! algal C to N (mole/mole)
       real (kind=dbl_kind), optional :: R_chl2N_in(:)      ! 3 algal chlorophyll to N (mg/mmol)
@@ -766,21 +744,6 @@
       character(len=*),parameter :: subname='(icepack_init_zbgc)'
 
       !--------
-
-      if (present(dictype_in))   dictype(:)   = dictype_in(:)
-      if (present(algaltype_in)) algaltype(:) = algaltype_in(:)
-      if (present(doctype_in))   doctype(:)   = doctype_in(:)
-      if (present(dontype_in))   dontype(:)   = dontype_in(:)
-      if (present(fedtype_in))   fedtype(:)   = fedtype_in(:)
-      if (present(feptype_in))   feptype(:)   = feptype_in(:)
-      if (present(zaerotype_in)) zaerotype(:) = zaerotype_in(:)
-
-      if (present(nitratetype_in))  nitratetype  = nitratetype_in
-      if (present(silicatetype_in)) silicatetype = silicatetype_in
-      if (present(ammoniumtype_in)) ammoniumtype = ammoniumtype_in
-      if (present(humtype_in))      humtype      = humtype_in
-      if (present(dmspptype_in))    dmspptype    = dmspptype_in
-      if (present(dmspdtype_in))    dmspdtype    = dmspdtype_in
 
       if (present(R_C2N_in))     R_C2N(:)     = R_C2N_in(:)
       if (present(R_chl2N_in))   R_chl2N(:)   = R_chl2N_in(:)

--- a/columnphysics/icepack_zbgc_shared.F90
+++ b/columnphysics/icepack_zbgc_shared.F90
@@ -40,28 +40,6 @@
       ! Algal types: Diatoms, flagellates, Phaeocycstis
       ! DOC        : Proteins, EPS, Lipids
       !-----------------------------------------------------------------
-      real (kind=dbl_kind), dimension(max_dic), public :: &
-         dictype   = (/-c1/)  ! not in namelist
-
-      real (kind=dbl_kind), dimension(max_algae), public :: &
-         algaltype   ! tau_min for both retention and release
-
-      real (kind=dbl_kind), dimension(max_doc), public :: &
-         doctype
-
-      real (kind=dbl_kind), dimension(max_don), public :: &
-         dontype
-
-      real (kind=dbl_kind), dimension(max_fe), public :: &
-         fedtype
-
-      real (kind=dbl_kind), dimension(max_fe), public :: &
-         feptype
-
-      real (kind=dbl_kind), public :: &
-         nitratetype, ammoniumtype, silicatetype, &
-         dmspptype, dmspdtype, humtype
-
       !------------------------------------------------------------
       ! Aerosol order and type should be consistent with order/type
       ! specified in delta Eddington:  1) hydrophobic black carbon;
@@ -69,8 +47,6 @@
       ! 4) dust (0.5-1.25 micron); 5) dust (1.25-2.5 micron);
       ! 6) dust (2.5-5 micron)
       !-------------------------------------------------------------
-      real (kind=dbl_kind), dimension(max_aero), public :: &
-         zaerotype
 
       ! bio parameters for algal_dyn
  

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -833,7 +833,19 @@
 
       call icepack_query_tracer_numbers(ntrcr_out=ntrcr)
       call icepack_query_tracer_flags(tr_aero_out=tr_aero)
-      call icepack_query_parameters(ktherm_out=ktherm, shortwave_out=shortwave)
+      call icepack_query_parameters(ktherm_out=ktherm, shortwave_out=shortwave, &
+         scale_bgc_out=scale_bgc, skl_bgc_out=skl_bgc, z_tracers_out=z_tracers, &
+         dEdd_algae_out=dEdd_algae, solve_zbgc_out=solve_zbgc, phi_snow_out=phi_snow, &
+         bgc_flux_type_out=bgc_flux_type, grid_o_out=grid_o, l_sk_out=l_sk, &
+         initbio_frac_out=initbio_frac, frazil_scav_out=frazil_scav, &
+         algal_vel_out=algal_vel, R_dFe2dust_out=R_dFe2dust, &
+         dustFe_sol_out=dustFe_sol, T_max_out=T_max, fsal_out=fsal, &
+         op_dep_min_out=op_dep_min, fr_graze_s_out=fr_graze_s, &
+         fr_graze_e_out=fr_graze_e, fr_mort2min_out=fr_mort2min, &
+         fr_dFe_out=fr_dFe, k_nitrif_out=k_nitrif, t_iron_conv_out=t_iron_conv, &
+         max_loss_out=max_loss, max_dfe_doc1_out=max_dfe_doc1, &
+         fr_resp_s_out=fr_resp_s, y_sk_DMS_out=y_sk_DMS, t_sk_conv_out=t_sk_conv, &
+         t_sk_ox_out=t_sk_ox)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call icedrv_system_abort(string=subname, &
           file=__FILE__, line=__LINE__)
@@ -847,12 +859,6 @@
       restore_bgc     = .false.  ! restore bgc if true
       solve_zsal      = .false.  ! update salinity tracer profile from solve_S_dt
       bgc_data_type   = 'default'! source of bgc data
-      scale_bgc       = .false.  ! initial bgc tracers proportional to S  
-      skl_bgc         = .false.  ! solve skeletal biochemistry 
-      z_tracers       = .false.  ! solve vertically resolved tracers
-      dEdd_algae      = .false.  ! dynamic algae contributes to shortwave absorption
-                                 ! in delta-Eddington calculation
-      solve_zbgc      = .false.  ! turn on z layer biochemistry 
       tr_bgc_PON      = .false.  !---------------------------------------------   
       tr_bgc_Nit      = .false.  ! biogeochemistry (skl or zbgc)
       tr_bgc_C        = .false.  ! if skl_bgc = .true. then skl
@@ -865,18 +871,8 @@
       tr_bgc_Fe       = .false.  ! 
       tr_bgc_N        = .true.   !
 
-      ! brine height parameter
-      phi_snow        = p5       ! snow porosity
-
-      ! skl biology parameters
-      bgc_flux_type   = 'Jin2006'! type of ocean-ice poston velocity ('constant')
-
       ! z biology parameters  
-      grid_o          = c5           ! for bottom flux        
       grid_o_t        = c5           ! for top flux        
-      l_sk            = 7.0_dbl_kind ! characteristic diffusive scale (m)   
-      initbio_frac    = c1           ! fraction of ocean trcr concentration in bio trcrs
-      frazil_scav     = c1           ! increase in initial bio tracer from ocean scavenging 
       ratio_Si2N_diatoms = 1.8_dbl_kind    ! algal Si to N (mol/mol)                       
       ratio_Si2N_sp      = c0              ! diatoms, small plankton, phaeocystis
       ratio_Si2N_phaeo   = c0
@@ -892,12 +888,8 @@
       ratio_Fe2DON       = 0.023_dbl_kind  ! Fe to N of DON (nmol/umol)
       ratio_Fe2DOC_s     = p1              ! Fe to C of DOC (nmol/umol) saccharids
       ratio_Fe2DOC_l     = 0.033_dbl_kind  ! Fe to C of DOC (nmol/umol) lipids
-      fr_resp            = 0.05_dbl_kind   ! frac of algal growth lost due to respiration      
       tau_min            = 5200.0_dbl_kind ! rapid mobile to stationary exchanges (s)
       tau_max            = 1.73e5_dbl_kind ! long time mobile to stationary exchanges (s)
-      algal_vel          = 1.11e-8_dbl_kind! 0.5 cm/d(m/s) Lavoie 2005  1.5 cm/day
-      R_dFe2dust         = 0.035_dbl_kind  !  g/g (3.5% content) Tagliabue 2009
-      dustFe_sol         = 0.005_dbl_kind  ! solubility fraction
       chlabs_diatoms     = 0.03_dbl_kind   ! chl absorption (1/m/(mg/m^3))
       chlabs_sp          = 0.01_dbl_kind
       chlabs_phaeo       = 0.05_dbl_kind
@@ -946,23 +938,6 @@
       f_exude_l          = c1
       k_bac_s            = 0.03_dbl_kind ! Bacterial degredation of DOC (1/d)
       k_bac_l            = 0.03_dbl_kind
-      T_max              = c0            ! maximum temperature (C)
-      fsal               = c1            ! Salinity limitation (1)
-      op_dep_min         = p1            ! Light attenuates for optical depths exceeding min
-      fr_graze_s         = p5            ! fraction of grazing spilled or slopped
-      fr_graze_e         = p5            ! fraction of assimilation excreted 
-      fr_mort2min        = p5            ! fractionation of mortality to Am
-      fr_dFe             = 0.3_dbl_kind  ! fraction of remineralized nitrogen
-                                         ! (in units of algal iron)
-      k_nitrif           = c0            ! nitrification rate (1/day)           
-      t_iron_conv        = 3065.0_dbl_kind ! desorption loss pFe to dFe (day)
-      max_loss           = 0.9_dbl_kind ! restrict uptake to % of remaining value 
-      max_dfe_doc1       = 0.2_dbl_kind ! max ratio of dFe to saccharides in the ice 
-                                         !(nM Fe/muM C)    
-      fr_resp_s          = 0.75_dbl_kind ! DMSPd fraction of respiration loss as DMSPd
-      y_sk_DMS           = p5            ! fraction conversion given high yield
-      t_sk_conv          = 3.0_dbl_kind  ! Stefels conversion time (d)
-      t_sk_ox            = 10.0_dbl_kind ! DMS oxidation time (d)
       algaltype_diatoms  = c0            ! ------------------
       algaltype_sp       = p5            !
       algaltype_phaeo    = p5            !
@@ -993,10 +968,6 @@
       F_abs_chl_sp       = 4.0_dbl_kind
       F_abs_chl_phaeo    = 5.0_dbl_kind
       ratio_C2N_proteins = 7.0_dbl_kind  ! ratio of C to N in proteins (mol/mol)       
-
-      ! z salinity  parameters
-      grid_oS         = c5            ! for bottom flux         
-      l_skS           = 7.0_dbl_kind  ! characteristic diffusive scale (m) 
 
       !-----------------------------------------------------------------
       ! read from input file
@@ -1218,23 +1189,21 @@
       ! set Icepack values
       !-----------------------------------------------------------------
 
-      call icepack_init_tracer_indices( &
-          nbtrcr_in=nbtrcr)
-      call icepack_warnings_flush(nu_diag)
-      if (icepack_warnings_aborted()) call icedrv_system_abort(string=subname, &
-          file=__FILE__, line=__LINE__)
-
-      call icepack_init_parameters( &
-          ktherm_in=ktherm, shortwave_in=shortwave, solve_zsal_in=solve_zsal, &
-          skl_bgc_in=skl_bgc, z_tracers_in=z_tracers, scale_bgc_in=scale_bgc, &
-          dEdd_algae_in=dEdd_algae, &
-          solve_zbgc_in=solve_zbgc, &
-          bgc_flux_type_in=bgc_flux_type, grid_o_in=grid_o, l_sk_in=l_sk, &
-          initbio_frac_in=initbio_frac, &
-          frazil_scav_in=frazil_scav, &
-          grid_oS_in=grid_oS, l_skS_in=l_skS, &
-          phi_snow_in=phi_snow, &
-          modal_aero_in=modal_aero)
+      call icepack_init_tracer_indices(nbtrcr_in=nbtrcr)
+      call icepack_init_parameters(ktherm_in=ktherm, shortwave_in=shortwave, &
+         scale_bgc_in=scale_bgc, skl_bgc_in=skl_bgc, z_tracers_in=z_tracers, &
+         dEdd_algae_in=dEdd_algae, solve_zbgc_in=solve_zbgc, &
+         bgc_flux_type_in=bgc_flux_type, grid_o_in=grid_o, l_sk_in=l_sk, &
+         initbio_frac_in=initbio_frac, frazil_scav_in=frazil_scav, &
+         grid_oS_in=grid_oS, l_skS_in=l_skS, phi_snow_in=phi_snow, &
+         algal_vel_in=algal_vel, R_dFe2dust_in=R_dFe2dust, &
+         dustFe_sol_in=dustFe_sol, T_max_in=T_max, fsal_in=fsal, &
+         op_dep_min_in=op_dep_min, fr_graze_s_in=fr_graze_s, &
+         fr_graze_e_in=fr_graze_e, fr_mort2min_in=fr_mort2min, &
+         fr_dFe_in=fr_dFe, k_nitrif_in=k_nitrif, t_iron_conv_in=t_iron_conv, &
+         max_loss_in=max_loss, max_dfe_doc1_in=max_dfe_doc1, fr_resp_in=fr_resp, &
+         fr_resp_s_in=fr_resp_s, y_sk_DMS_in=y_sk_DMS, t_sk_conv_in=t_sk_conv, &
+         t_sk_ox_in=t_sk_ox, modal_aero_in=modal_aero)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call icedrv_system_abort(string=subname, &
           file=__FILE__, line=__LINE__)

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -632,7 +632,7 @@
           bgc_flux_type
 
       real (kind=dbl_kind) :: &
-          grid_o, l_sk, grid_o_t, initbio_frac, &
+          grid_o, l_sk, initbio_frac, &
           frazil_scav, grid_oS, l_skS, &
           phi_snow, &
           ratio_Si2N_diatoms , ratio_Si2N_sp      , ratio_Si2N_phaeo   ,  &
@@ -786,7 +786,7 @@
         restore_bgc, scale_bgc, solve_zsal, bgc_data_type, &
         tr_bgc_Nit, tr_bgc_C, tr_bgc_chl, tr_bgc_Am, tr_bgc_Sil, &
         tr_bgc_DMS, tr_bgc_PON, tr_bgc_hum, tr_bgc_DON, tr_bgc_Fe, &
-        grid_o, grid_o_t, l_sk, grid_oS, &   
+        grid_o, l_sk, grid_oS, &
         l_skS, phi_snow,  initbio_frac, frazil_scav, &
         ratio_Si2N_diatoms , ratio_Si2N_sp      , ratio_Si2N_phaeo   ,  &
         ratio_S2N_diatoms  , ratio_S2N_sp       , ratio_S2N_phaeo    ,  &
@@ -872,7 +872,6 @@
       tr_bgc_N        = .true.   !
 
       ! z biology parameters  
-      grid_o_t        = c5           ! for top flux        
       ratio_Si2N_diatoms = 1.8_dbl_kind    ! algal Si to N (mol/mol)                       
       ratio_Si2N_sp      = c0              ! diatoms, small plankton, phaeocystis
       ratio_Si2N_phaeo   = c0
@@ -1423,7 +1422,6 @@
       zaerotype(5) = zaerotype_dust3
       zaerotype(6) = zaerotype_dust4
 
-!echmod types do not need to be in icepack for zbgc?
       call icepack_init_zbgc ( &
          R_Si2N_in=R_Si2N, &
          R_S2N_in=R_S2N, R_Fe2C_in=R_Fe2C, R_Fe2N_in=R_Fe2N, R_C2N_in=R_C2N, &
@@ -1437,9 +1435,6 @@
          K_Nit_in=K_Nit, K_Am_in=K_Am, K_sil_in=K_Sil, K_Fe_in=K_Fe, &
          f_don_in=f_don, kn_bac_in=kn_bac, f_don_Am_in=f_don, f_exude_in=f_exude, &
          k_bac_in=k_bac, &
-         algaltype_in=algaltype, doctype_in=doctype, dontype_in=dontype, &
-         dictype_in=dictype, &
-         fedtype_in=fedtype, feptype_in=feptype, zaerotype_in=zaerotype, &
          fr_resp_in=fr_resp, algal_vel_in=algal_vel, R_dFe2dust_in=R_dFe2dust, &
          dustFe_sol_in=dustFe_sol, T_max_in=T_max, fr_mort2min_in=fr_mort2min, &
          fr_dFe_in=fr_dFe, op_dep_min_in=op_dep_min, &
@@ -1447,10 +1442,7 @@
          k_nitrif_in=k_nitrif, t_iron_conv_in=t_iron_conv, &
          max_loss_in=max_loss, max_dfe_doc1_in=max_dfe_doc1, &
          fr_resp_s_in=fr_resp_s, y_sk_DMS_in=y_sk_DMS, &
-         t_sk_conv_in=t_sk_conv, t_sk_ox_in=t_sk_ox, fsal_in=fsal, &
-         nitratetype_in=nitratetype, ammoniumtype_in=ammoniumtype, &
-         silicatetype_in=silicatetype, &
-         humtype_in=humtype, dmspptype_in=dmspptype, dmspdtype_in=dmspdtype)
+         t_sk_conv_in=t_sk_conv, t_sk_ox_in=t_sk_ox, fsal_in=fsal)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call icedrv_system_abort(string=subname, &
           file=__FILE__, line=__LINE__)
@@ -1873,9 +1865,7 @@
          write(nu_diag,1010) ' tr_bgc_PON                = ', tr_bgc_PON
          write(nu_diag,1010) ' tr_bgc_DON                = ', tr_bgc_DON
          write(nu_diag,1010) ' tr_bgc_Fe                 = ', tr_bgc_Fe 
-         !bio parameters
          write(nu_diag,1000) ' grid_o                    = ', grid_o
-         write(nu_diag,1000) ' grid_o_t                  = ', grid_o_t
          write(nu_diag,1005) ' l_sk                      = ', l_sk
          write(nu_diag,1000) ' initbio_frac              = ', initbio_frac
          write(nu_diag,1000) ' frazil_scav               = ', frazil_scav  

--- a/configuration/scripts/icepack_in
+++ b/configuration/scripts/icepack_in
@@ -99,7 +99,6 @@
     tr_bgc_DON      = .false.
     tr_bgc_Fe       = .false. 
     grid_o          = 0.006
-    grid_o_t        = 0.006
     l_sk            = 0.024
     grid_oS         = 0.0
     l_skS           = 0.028

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -257,7 +257,6 @@ column physics.
    "``tr_bgc_DON``", "true/false", "dissolved organic nitrogen", "``.true.``"
    "``tr_bgc_Fe``", "true/false", "dissolved iron and particulate iron", "``.true.``"
    "``grid_o``", "real", "ice-ocean surface layer thickness (bgc transport scheme)", "0.006"
-   "``grid_o_t``", "real", "ice-atmosphere surface layer thickness (bgc transport scheme)", "0.006"
    "``l_sk``", "real", "length scale in gravity drainage parameterization (bgc transport scheme)", "0.024"
    "``grid_oS``", "real", "ice-ocean surface layer thickness (zsalinity transport scheme)", "0.0"
    "``l_skS``", "real", "ice-atmosphere surface layer thickness (zsalinity transport scheme)", "0.028"


### PR DESCRIPTION
Moving bgc namelist defaults into columnphysics, cleaning up.
Developer(s):   E Hunke
Are the code changes bit for bit, different at roundoff level, or more substantial?   BFB
Is the documentation being updated with this PR? (Y/N)  Y
If not, does the documentation need to be updated separately? (Y/N)
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/Icepack/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:
Removed grid_o_t completely because it is not used anywhere (including in CICE).
The 'type' variables are needed only for setting parameters at initialization, not during the columnphysics calculations.
See https://github.com/CICE-Consortium/Test-Results/wiki/30436c16a7.pinto.intel.180203214537