### PR TITLE
fix more icepack debug errors

### DIFF
--- a/columnphysics/icepack_atmo.F90
+++ b/columnphysics/icepack_atmo.F90
@@ -161,7 +161,7 @@
          psimhu, & ! unstable part of psimh
          psixhu    ! unstable part of psimx
 
-      character(len=*),parameter :: subname='(atm_boundary_layer)'
+      character(len=*),parameter :: subname='(atmo_boundary_layer)'
 
       !------------------------------------------------------------
       ! Define functions
@@ -389,8 +389,7 @@
                                       Tsf,      potT,     &
                                       Qa,                 &
                                       delt,     delq,     &
-                                      lhcoef,   shcoef,   &
-                                      Cdn_atm)  
+                                      lhcoef,   shcoef    )
 
       character (len=3), intent(in) :: &
          sfctype      ! ice or ocean
@@ -406,9 +405,6 @@
          vatm     , & ! y-direction wind speed (m/s)
          wind     , & ! wind speed (m/s)
          rhoa         ! air density (kg/m^3)
-
-      real (kind=dbl_kind), intent(in) :: &
-         Cdn_atm      ! neutral drag coefficient
 
       real (kind=dbl_kind), intent(inout):: &
          strx     , & ! x surface stress (N)
@@ -429,7 +425,7 @@
          tau, &  ! stress at zlvl
          Lheat   ! Lvap or Lsub, depending on surface type
 
-      character(len=*),parameter :: subname='(atm_boundary_const)'
+      character(len=*),parameter :: subname='(atmo_boundary_const)'
 
       !------------------------------------------------------------
       ! Initialize
@@ -901,6 +897,8 @@
          worku = uvel
       endif
 
+      Cdn_atm_ratio_n = c1
+
                if (trim(atmbndy) == 'constant') then
                   call atmo_boundary_const (sfctype,  calc_strair, &
                                             uatm,     vatm,     &
@@ -909,8 +907,7 @@
                                             Tsf,      potT,     &
                                             Qa,                 &
                                             delt,     delq,     &
-                                            lhcoef,   shcoef,   &
-                                            Cdn_atm)
+                                            lhcoef,   shcoef    )
                   if (icepack_warnings_aborted(subname)) return
                else ! default
                   call atmo_boundary_layer (sfctype,                 &

--- a/columnphysics/icepack_brine.F90
+++ b/columnphysics/icepack_brine.F90
@@ -8,7 +8,7 @@
       module icepack_brine
 
       use icepack_kinds
-      use icepack_parameters, only: p01, p001, p5, c0, c1, c2, c1p5, puny
+      use icepack_parameters, only: p01, p001, p5, c0, c1, c2, c1p5, c10, puny
       use icepack_parameters, only: gravit, rhoi, rhow, rhos, depressT
       use icepack_parameters, only: salt_loss, min_salin, rhosi
       use icepack_parameters, only: dts_b, l_sk
@@ -44,6 +44,9 @@
          ! Brine density as a quadratic of brine salinity
          b1      = 1000.0_dbl_kind, & ! (kg/m^3)  
          b2      = 0.8_dbl_kind       ! (kg/m^3/ppt)
+
+      real (kind=dbl_kind), parameter :: & 
+         exp_argmax = c10    ! maximum argument of exponential
 
 !=======================================================================
 
@@ -511,6 +514,7 @@
          darcy_coeff, & ! magnitude of the Darcy velocity/hbrocn (1/s)
          hbrocn_new , & ! hbrocn after flushing
          dhflood    , & ! surface flooding by ocean
+         exp_min    , & ! temporary exp value
          dhrunoff       ! direct runoff to ocean
 
       real (kind=dbl_kind), parameter :: &
@@ -540,7 +544,8 @@
                bphi_min   = bphin  
                dhrunoff  = -dhS_top*aice0
                hbrocn    = max(c0,hbrocn - dhrunoff)
-               hbrocn_new = hbrocn*exp(-darcy_coeff/bphi_min*dt)
+               exp_min = min(darcy_coeff/bphi_min*dt,exp_argmax)
+               hbrocn_new = hbrocn*exp(-exp_min)
                hbr = max(hbrmin, h_ocn + hbrocn_new)
                hbrocn_new = hbr-h_ocn
                darcy_V = -SIGN((hbrocn-hbrocn_new)/dt*bphi_min, hbrocn)

--- a/columnphysics/icepack_brine.F90
+++ b/columnphysics/icepack_brine.F90
@@ -545,11 +545,12 @@
                dhrunoff  = -dhS_top*aice0
                hbrocn    = max(c0,hbrocn - dhrunoff)
                exp_arg = darcy_coeff/bphi_min*dt
-               if (exp_arg > exp_argmax) then
-                  hbrocn_new = c0
-               else
+! tcx tcraig avoids underflows but is not bit-for-bit
+!               if (exp_arg > exp_argmax) then
+!                  hbrocn_new = c0
+!               else
                   hbrocn_new = hbrocn*exp(-exp_arg)
-               endif
+!               endif
                hbr = max(hbrmin, h_ocn + hbrocn_new)
                hbrocn_new = hbr-h_ocn
                darcy_V = -SIGN((hbrocn-hbrocn_new)/dt*bphi_min, hbrocn)

--- a/columnphysics/icepack_brine.F90
+++ b/columnphysics/icepack_brine.F90
@@ -46,7 +46,7 @@
          b2      = 0.8_dbl_kind       ! (kg/m^3/ppt)
 
       real (kind=dbl_kind), parameter :: & 
-         exp_argmax = c10    ! maximum argument of exponential
+         exp_argmax = 30.0_dbl_kind    ! maximum argument of exponential for underflow
 
 !=======================================================================
 
@@ -514,7 +514,7 @@
          darcy_coeff, & ! magnitude of the Darcy velocity/hbrocn (1/s)
          hbrocn_new , & ! hbrocn after flushing
          dhflood    , & ! surface flooding by ocean
-         exp_min    , & ! temporary exp value
+         exp_arg    , & ! temporary exp value
          dhrunoff       ! direct runoff to ocean
 
       real (kind=dbl_kind), parameter :: &
@@ -544,8 +544,12 @@
                bphi_min   = bphin  
                dhrunoff  = -dhS_top*aice0
                hbrocn    = max(c0,hbrocn - dhrunoff)
-               exp_min = min(darcy_coeff/bphi_min*dt,exp_argmax)
-               hbrocn_new = hbrocn*exp(-exp_min)
+               exp_arg = darcy_coeff/bphi_min*dt
+               if (exp_arg > exp_argmax) then
+                  hbrocn_new = c0
+               else
+                  hbrocn_new = hbrocn*exp(-exp_arg)
+               endif
                hbr = max(hbrmin, h_ocn + hbrocn_new)
                hbrocn_new = hbr-h_ocn
                darcy_V = -SIGN((hbrocn-hbrocn_new)/dt*bphi_min, hbrocn)

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -678,7 +678,7 @@
          zSin            ! internal ice layer salinities
         
       real (kind=dbl_kind), dimension (:), &
-         intent(out) :: &
+         intent(inout) :: &
          zqsn        , & ! snow enthalpy
          zTsn            ! snow temperature
 

--- a/configuration/driver/icedrv_InitMod.F90
+++ b/configuration/driver/icedrv_InitMod.F90
@@ -135,7 +135,7 @@
       use icedrv_init_column, only: init_hbrine, init_bgc
       use icedrv_restart, only: restartfile
       use icedrv_restart_shared, only: restart
-      use icedrv_restart_column, only: read_restart_bgc
+      use icedrv_restart_bgc, only: read_restart_bgc
       use icedrv_state ! almost everything
 
       integer(kind=int_kind) :: &

--- a/configuration/driver/icedrv_RunMod.F90
+++ b/configuration/driver/icedrv_RunMod.F90
@@ -94,7 +94,7 @@
       use icedrv_flux, only: scale_factor, init_history_therm, init_history_bgc, &
           daidtt, daidtd, dvidtt, dvidtd, dagedtt, dagedtd, init_history_dyn
       use icedrv_restart, only: dumpfile, final_restart
-      use icedrv_restart_column, only: write_restart_bgc
+      use icedrv_restart_bgc, only: write_restart_bgc
       use icedrv_state, only: trcrn
       use icedrv_step, only: prep_radiation, step_therm1, step_therm2, &
           update_state, step_dyn_ridge, step_radiation, &

--- a/configuration/driver/icedrv_restart_bgc.F90
+++ b/configuration/driver/icedrv_restart_bgc.F90
@@ -4,7 +4,7 @@
 !
 ! author: Elizabeth C. Hunke, LANL
 !
-      module icedrv_restart_column
+      module icedrv_restart_bgc
 
       use icedrv_kinds
       use icedrv_constants
@@ -20,7 +20,8 @@
       implicit none
 
       private
-      public ::  write_restart_bgc,       read_restart_bgc
+      public ::  write_restart_bgc, &
+                 read_restart_bgc
 
 !=======================================================================
 
@@ -667,6 +668,6 @@
 
 !=======================================================================
 
-      end module icedrv_restart_column
+      end module icedrv_restart_bgc
 
 !=======================================================================

--- a/configuration/scripts/tests/report_results.csh
+++ b/configuration/scripts/tests/report_results.csh
@@ -140,8 +140,8 @@ if ( ${case} =~ *_${compiler}_* ) then
   if (${fcomp}  == "") set rcomp  = ${gray}
   if (${ftime}  == "") set rtime  = ${gray}
 
-  set fcomp  = `grep " ${case} " results.log | grep " bfbcomp" | grep "baseline-does-not-exist" | wc -l `
-  if ($fcomp > 1) set rcomp = ${gray}
+  set fregrx  = `grep " ${case} " results.log | grep " compare" | grep "baseline-does-not-exist" | wc -l `
+  if ($fregrx > 0) set rregr = ${gray}
 
   if (${rbuild} == ${red}) set tchkpass = 0
   if (${rrun}   == ${red}) set tchkpass = 0

--- a/doc/source/developer_guide/dg_driver.rst
+++ b/doc/source/developer_guide/dg_driver.rst
@@ -29,7 +29,7 @@ The icepack driver consists of the following files
 |        **icedrv_init.F90**        general initialization routines
 |        **icedrv_init_column.F90** initialization routines specific to the column physics
 |        **icedrv_restart.F90**     driver for reading/writing restart files
-|        **icedrv_restart_column.F90**  restart routines specific to the column physics
+|        **icedrv_restart_bgc.F90**  restart routines specific to the column physics
 |        **icedrv_restart_shared.F90**  code shared by all restart options
 |        **icedrv_state.F90**       essential arrays to describe the state of the ice
 |        **icedrv_step.F90**        routines for time stepping the major code components


### PR DESCRIPTION
fix more icepack debug errors.  in particular,
  fix exp underflows and errors in icepack_algae (issue #126 ), icepack_brine (issue #129).
  remove cdn_atm from atm_boundary_const (#125)
  rename icedrv_restart_column to icedrv_restart_bgc (#100)
  fix zqsn intent in subroutine init_vertical_profile (#103)
Developer(s): tcraig
Are the code changes bit for bit, different at roundoff level, or more substantial? bfb except bgcISPOL
Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately? (Y/N) N
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/Icepack/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:

All tests pass on gordon, https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks, hash# a9718648d.  All results are bit-for-bit except bgcISPOL.  

bgcISPOL are bit-for-bit in the log files for the full-ITD case, land, and slab gridpoints.

bgcISPOL results are different for the icefree case, diverging first here,
```
< avg brine thickness (m)=        0.09317749194835656
---
> avg brine thickness (m)=        0.09317747986181293

```
