### PR TITLE
Update to atmospheric documentation

### DIFF
--- a/columnphysics/icepack_atmo.F90
+++ b/columnphysics/icepack_atmo.F90
@@ -308,7 +308,7 @@
          if (highfreq .and. sfctype(1:3)=='ice') then
 
             !------------------------------------------------------------
-            ! momentum flux for RASM
+            ! momentum flux for high frequency coupling (RASM/CESM) 
             !------------------------------------------------------------
             ! tau = rhoa * rd * rd
             ! strx = tau * |Uatm-U| * (uatm-u)

--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -47,6 +47,7 @@
 @string{NTN = {NCAR Tech. Note}}
 @string{BGC = {Biogeochemistry}}
 @string{EFM = {Eng. Fract. Mech.}}
+@string{ANG = {Ann. Glaciol.}}
 
 % Individual entries (roughly sequential, then alphabetical but first-author’s last name)
 @incollection{Assur58,
@@ -758,3 +759,14 @@
   pages = {1329-1353},
   url = {https://doi.org/10.1175/JPO-D-13-0215.1}
 }
+@Article{Roberts2015,
+  author = {A.F. Roberts and A. Craig and W. Maslowski and R. Osinski and A. Duvivier and M. Hughes and B. Nijssen and J.J. Cassano. and M. Brunke},
+  url = {https://doi.org/10.3189/2015AoG69A760},
+  journal = ANG,
+  number = {69},
+  pages = {211--228},
+  title = {{Simulating transient ice-ocean Ekman transport in the Regional Arctic System Model and Community Earth System Model}},
+  volume = {56},
+  year = {2015}
+}
+


### PR DESCRIPTION
This pull request brings the description of the physics in icepack_atmo.F90 up-to-date in doc/source/science_guide/sg_boundary_forcing.rst, and includes the addition of one reference and a change to a single comment line in  icepack_atmo.F90.  There is no change to any calculations.

Are the code changes bit-for-bit, different at roundoff level, or more substantial? BIT-FOR-BIT
Is the documentation being updated with this PR? YES
