### PR TITLE
update icepack.setup checks and icepack_warnings

### DIFF
--- a/columnphysics/icepack_warnings.F90
+++ b/columnphysics/icepack_warnings.F90
@@ -59,10 +59,12 @@ contains
 
         warning_abort = abortflag
 
-        write(warnstr,*) subname,abortflag
-        if (present(file)) write(warnstr,*) trim(warnstr)//' :file '//trim(file)
-        if (present(line)) write(warnstr,*) trim(warnstr)//' :line ',line
-        call icepack_warnings_add(warnstr)
+! tcx. tcraig,take this out as it tends to write from all pes in all runs
+! may want to consider separating info and error messages somehow
+!        write(warnstr,*) subname,abortflag
+!        if (present(file)) write(warnstr,*) trim(warnstr)//' :file '//trim(file)
+!        if (present(line)) write(warnstr,*) trim(warnstr)//' :line ',line
+!        call icepack_warnings_add(warnstr)
 
       end subroutine icepack_warnings_setabort
 

--- a/icepack.setup
+++ b/icepack.setup
@@ -227,28 +227,33 @@ if ($machine == $spval) then
 endif
 
 if ($case == $spval && $test == $spval && $testsuite == $spval) then
-  echo "${0}: ERROR in arguments, -c, -t, or -ts required"
+  echo "${0}: ERROR in arguments, --case, --test, or --suite required"
   exit -1
 endif
 
 if ($case != $spval && $test != $spval) then
-  echo "${0}: ERROR in arguments, cannot use both -c and -t"
+  echo "${0}: ERROR in arguments, cannot use both --case and --test"
   exit -1
 endif
 
 if ($case != $spval && $testsuite != $spval) then
-  echo "${0}: ERROR in arguments, cannot use both -c and -ts"
+  echo "${0}: ERROR in arguments, cannot use both --case and --suite"
   exit -1
 endif
 
 if ($testsuite != $spval && $test != $spval) then
-  echo "${0}: ERROR in arguments, cannot use both -ts and -t"
+  echo "${0}: ERROR in arguments, cannot use both --suite and --test"
+  exit -1
+endif
+
+if ($report == 1 && $testsuite == $spval) then
+  echo "${0}: ERROR in arguments, must use --suite with --report"
   exit -1
 endif
 
 if ($testsuite == $spval) then
   if ("$compilers" =~ "*,*") then
-    echo "${0}: ERROR in arguments, cannot set multiple compilers without -ts"
+    echo "${0}: ERROR in arguments, cannot set multiple compilers without --suite"
     exit -1
   else
     set compiler = ${compilers}
@@ -264,7 +269,7 @@ endif
 #endif
 
 if (($testsuite != $spval || $test != $spval) && $testid == $spval) then
-  echo "${0}: ERROR in arguments.  -testid must be passed if using -ts or -t"
+  echo "${0}: ERROR in arguments.  -testid must be passed if using --suite or --test"
   exit -1
 endif
 


### PR DESCRIPTION
update icepack.setup checks and comment out output in icepack_warnings_setabort that was creating lots of messages in CICE.

Developer(s): tcraig
Are the code changes bit for bit, different at roundoff level, or more substantial? bfb
Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately? (Y/N) N
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/Icepack/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:

addresses #147 and #128 
