### PR TITLE
ISPOL data interpolation bug

### DIFF
--- a/configuration/scripts/tests/timeseries.csh
+++ b/configuration/scripts/tests/timeseries.csh
@@ -28,7 +28,7 @@ set fieldlist=("area fraction  " \
                "lateral melt (m)" \
                "new ice (m)" \
                "congelation (m)" \
-               "snow-ice (m)" \
+#               "snow-ice (m)" \
                "intnl enrgy chng(W/m^2)")
 
 # Get the filename for the latest log


### PR DESCRIPTION
Add time offset to interpolation routine
Developer(s):  E. Hunke
Are the code changes bit for bit, different at roundoff level, or more substantial?  BFB except ISPOL
Is the documentation being updated with this PR? (Y/N)  N
If not, does the documentation need to be updated separately? (Y/N)  N
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/Icepack/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:

This addresses Issue #151 and if the gods are with me, #96 

The first data record in the ISPOL and NICE data is the beginning of the field campaigns (June 17 and April 24, respectively).  The code assumed that the first record was Jan 1.  This sometimes caused the thermo to fail with bad data values.  The code now runs and restarts properly (I think).  This changes the answers for the ISPOL case.  NICE has not been tested.  

A potential lingering bug is that the ISPOL and NICE ocean data might be offset too, but variations in these fields do not matter so much.

I also commented out the snow-ice field from timeseries.csh.  It was sometimes causing the script to get into an infinite loop.  (why?)