### PR TITLE
Make Timeseries fonts larger

### DIFF
--- a/configuration/scripts/tests/timeseries.csh
+++ b/configuration/scripts/tests/timeseries.csh
@@ -10,14 +10,6 @@ endif
 #set basename = `echo $1:t`
 set basename = $1
 
-# Find the font file for (1) Arial, (2) Times, or (3) Courier
-set font_full = `fc-list : file family style | grep "\.ttf\|\.pfa" | grep -P -v "[\x80-\xFF]"`
-set font_full = `echo $font_full | grep Regular | head -n 1 | cut -d: -f 1`
-setenv GDFONTPATH `echo $font_full | rev | cut -d / -f 2- | rev`
-set fnt = `echo $font_full | rev | cut -d / -f 1 | rev`
-
-echo "Font = $fnt"
-
 set fieldlist=("area fraction  " \
                "avg ice thickness (m)" \
                "avg snow depth (m)" \
@@ -101,12 +93,11 @@ set timefmt "$format"
 set format x "%Y/%m/%d"
 
 # Axis tick marks
-set xtics rotate font "$fnt,12"
-set ytics font "$fnt,12"
+set xtics rotate
 
-set title "$fname_base" font "$fnt,18"
-set ylabel "$field" font "$fnt,14" offset -1,0
-set xlabel "Simulation Day" font "$fnt,14" offset 0,-4
+set title "$fname_base"
+set ylabel "$field"
+set xlabel "Simulation Day"
 
 # Set y-axis limits
 $yrange

--- a/configuration/scripts/tests/timeseries.csh
+++ b/configuration/scripts/tests/timeseries.csh
@@ -10,6 +10,11 @@ endif
 #set basename = `echo $1:t`
 set basename = $1
 
+# Find the font file for an Arial font
+set font_full = `fc-list : file family style | grep Arial | head -n 1 | cut -d: -f 1`
+setenv GDFONTPATH `dirname $font_full`
+set fnt = `basename $font_full`
+
 set fieldlist=("area fraction  " \
                "avg ice thickness (m)" \
                "avg snow depth (m)" \
@@ -71,12 +76,14 @@ foreach field ($fieldlist:q)
   endif
 
   set output = `echo $fieldname | sed 's/ /_/g'`
-  set output = "${basename}_${output}.png"
+  set casename = `echo $basename | rev | cut -d / -f 1-2 | rev | sed 's/\//, /'`
+  set fname_base = "${casename}_${output}"
+  set output_fname = "${basename}_${output}.png"
 
-  echo "Plotting data for '$fieldname' and saving to $output"
+  echo "Plotting data for '$fieldname' and saving to $output_fname"
 
 # Call the plotting routine, which uses the data in the data.txt file
-gnuplot << EOF > $output
+gnuplot << EOF > $output_fname
 # Plot style
 set style data points
 
@@ -91,11 +98,12 @@ set timefmt "$format"
 set format x "%Y/%m/%d"
 
 # Axis tick marks
-set xtics rotate
+set xtics rotate font "$fnt,12"
+set ytics font "$fnt,12"
 
-set title "Annual ICEPACK Test $field (Diagnostic Print)" 
-set ylabel "$field" 
-set xlabel "Simulation Day" 
+set title "$fname_base" font "$fnt,18"
+set ylabel "$field" font "$fnt,14" offset -1,0
+set xlabel "Simulation Day" font "$fnt,14" offset 0,-4
 
 # Set y-axis limits
 $yrange

--- a/configuration/scripts/tests/timeseries.csh
+++ b/configuration/scripts/tests/timeseries.csh
@@ -11,15 +11,12 @@ endif
 set basename = $1
 
 # Find the font file for (1) Arial, (2) Times, or (3) Courier
-set font_full = `fc-list : file family style | grep Arial | grep Regular | head -n 1 | cut -d: -f 1`
-if ( "$font_full" == "" ) then
-  set font_full = `fc-list : file family style | grep Times | grep Regular | head -n 1 | cut -d: -f 1`
-  if ( "$font_full" == "" ) then
-    set font_full = `fc-list : file family style | grep Courier | grep Regular | head -n 1 | cut -d: -f 1`
-  endif
-endif
+set font_full = `fc-list : file family style | grep "\.ttf\|\.pfa" | grep -P -v "[\x80-\xFF]"`
+set font_full = `echo $font_full | grep Regular | head -n 1 | cut -d: -f 1`
 setenv GDFONTPATH `echo $font_full | rev | cut -d / -f 2- | rev`
 set fnt = `echo $font_full | rev | cut -d / -f 1 | rev`
+
+echo "Font = $fnt"
 
 set fieldlist=("area fraction  " \
                "avg ice thickness (m)" \

--- a/configuration/scripts/tests/timeseries.csh
+++ b/configuration/scripts/tests/timeseries.csh
@@ -10,8 +10,14 @@ endif
 #set basename = `echo $1:t`
 set basename = $1
 
-# Find the font file for an Arial font
-set font_full = `fc-list : file family style | grep Arial | head -n 1 | cut -d: -f 1`
+# Find the font file for (1) Arial, (2) Times, or (3) Courier
+set font_full = `fc-list : file family style | grep Arial | grep Regular | head -n 1 | cut -d: -f 1`
+if ( "$font_full" == "" ) then
+  set font_full = `fc-list : file family style | grep Times | grep Regular | head -n 1 | cut -d: -f 1`
+  if ( "$font_full" == "" ) then
+    set font_full = `fc-list : file family style | grep Courier | grep Regular | head -n 1 | cut -d: -f 1`
+  endif
+endif
 setenv GDFONTPATH `dirname $font_full`
 set fnt = `basename $font_full`
 

--- a/configuration/scripts/tests/timeseries.csh
+++ b/configuration/scripts/tests/timeseries.csh
@@ -18,8 +18,8 @@ if ( "$font_full" == "" ) then
     set font_full = `fc-list : file family style | grep Courier | grep Regular | head -n 1 | cut -d: -f 1`
   endif
 endif
-setenv GDFONTPATH `dirname $font_full`
-set fnt = `basename $font_full`
+setenv GDFONTPATH `echo $font_full | rev | cut -d / -f 2- | rev`
+set fnt = `echo $font_full | rev | cut -d / -f 1 | rev`
 
 set fieldlist=("area fraction  " \
                "avg ice thickness (m)" \


### PR DESCRIPTION
This PR updates the timeseries.csh script to make the fonts larger.  The case name is also now included in the figure title.

Developer(s): Matt Turner
Are the code changes bit for bit, different at roundoff level, or more substantial? N/A - changes are to plotting script only
Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately? (Y/N) N
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/Icepack/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:
- Also addresses https://github.com/CICE-Consortium/Icepack/issues/150 (or is an attempt at addressing it)