### PR TITLE
Print runlogs in Travis-CI if any tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ notifications:
   email: false
 
 after_failure:
+  - "for runlog in 
+    $(find travis_suite.travisCItest/*.travisCItest/logs/icepack.runlog.*)'; do
+    echo \"### Contents of $runlog ###\" && cat $runlog; done"
   - "git config --global user.email 'travis@travis-ci.org' &&
     git config --global user.name 'ciceconsortium' &&
     ./report_results.csh --travisCI"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ notifications:
 
 after_failure:
   - "for runlog in 
-    $(find travis_suite.travisCItest/*.travisCItest/logs/icepack.runlog.*)'; do
+    $(find travis_suite.travisCItest/*.travisCItest/logs/icepack.runlog.*); do
     echo \"### Contents of $runlog ###\" && cat $runlog; done"
   - "git config --global user.email 'travis@travis-ci.org' &&
     git config --global user.name 'ciceconsortium' &&


### PR DESCRIPTION
Travis-CI will print the contents of all `runlog` files to stdout if any of the tests in *travis_suite* fail.

I am not able to verify this change myself, as the current tests in the master branch [CICE-Consortium/Icepack](https://github.com/CICE-Consortium/Icepack) pass, thus not invoking the `after_failure` hook.

*Developer(s):* Anders Damsgaard, Princeton/NOAA-GFDL ([github.com/anders-dc](https://github.com/anders-dc), [adamsgaard.dk](https://adamsgaard.dk))

*Are the code changes bit for bit, different at roundoff level, or more substantial?* There are no changes to the underlying code.

*Is the documentation being updated with this PR? (Y/N)* No.

*If not, does the documentation need to be updated separately? (Y/N)* No.