### PR TITLE
Reference full path when looping over runlogs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ notifications:
   email: false
 
 after_failure:
-  - "for runlog in travis_suite.travisCItest/*.travisCItest/logs/icepack.runlog.*; do
+  - "for runlog in $TRAVIS_BUILD_DIR/travis_suite.travisCItest/*.travisCItest/logs/icepack.runlog.*; do
     echo \"### Contents of $runlog ###\" && cat $runlog; done"
   - "git config --global user.email 'travis@travis-ci.org' &&
     git config --global user.name 'ciceconsortium' &&


### PR DESCRIPTION
v1.0.0.d0001  This PR contains a small fix that makes sure that the runlogs are correctly found if a build fails on Travis.

*Developer(s):* Anders Damsgaard, Princeton/NOAA-GFDL

*Are the code changes bit for bit, different at roundoff level, or more substantial?* There are no changes to the underlying code.

*Is the documentation being updated with this PR? (Y/N)* No.

*If not, does the documentation need to be updated separately? (Y/N)* No.