### PR TITLE
Added quotes to fix  icepack.script problem on Mac OS X v1.0.0.d0003 

### DIFF
--- a/icepack.setup
+++ b/icepack.setup
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 
 set ICE_SANDBOX = `pwd`
-set ICE_SCRIPTS = ${ICE_SANDBOX}/configuration/scripts
+set ICE_SCRIPTS = "${ICE_SANDBOX}/configuration/scripts"
 set initargv = ( $argv[*] ) 
 
 set helpheader = 0


### PR DESCRIPTION
This small tweak fixes issue #174: "Bug in icepack.setup" :
When running on Mac OSX, the operating system allows spaces to occur in paths:
e.g. "/Volumes/Promise RAID/work/Icepack"
However, if icepack.setup is run from such a location, it crashes, because the lines:
set ICE_SANDBOX = pwd
set ICE_SCRIPTS = ${ICE_SANDBOX}/configuration/scripts
Do not allow for this occurrence. Placing quotes or parentheses around the second line fixes the problem:
set ICE_SCRIPTS = "${ICE_SANDBOX}/configuration/scripts"

Are the code changes bit for bit, different at roundoff level, or more substantial? BIT-FOR-BIT
Is the documentation being updated with this PR? NO
If not, does the documentation need to be updated separately? NO
Please suggest code reviewers in the column at right: TONY
~                                                            