### PR TITLE
Measure test coverage and report to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ addons:
 
 install:
   # Fetch Icepack-specific dataset
-  - "wget ftp://ftp.cgd.ucar.edu/archive/Model-Data/CICE/Icepack_data.tar.gz &&
-    tar xvfz Icepack_data.tar.gz -C ~"
+  #- "wget ftp://ftp.cgd.ucar.edu/archive/Model-Data/CICE/Icepack_data.tar.gz &&
+  #tar xvfz Icepack_data.tar.gz -C ~"
 
   # Mirror entire data folder
   #- "lftp ftp://anonymous:travis@travis-ci.org@ftp.cgd.ucar.edu 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,9 @@ notifications:
   email: false
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -s ~/ICEPACK_RUNS/
+  - "for dir in $HOME/ICEPACK_RUNS/*/; do
+    cp $dir/compile/*.{gcno,gcda} $TRAVIS_BUILD_DIR/columnphysics/ &&
+    bash <(curl -s https://codecov.io/bash); done"
 
 after_failure:
   - "for runlog in $TRAVIS_BUILD_DIR/travis_suite.travisCItest/*.travisCItest/logs/icepack.runlog.*; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ notifications:
   email: false
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -s ~/ICEPACK_RUNS/
 
 after_failure:
   - "for runlog in $TRAVIS_BUILD_DIR/travis_suite.travisCItest/*.travisCItest/logs/icepack.runlog.*; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,16 @@ language: cpp
 
 sudo: false
 
-compiler: clang
-
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
     packages:
       - tcsh
       - pkg-config
       - netcdf-bin
       - libnetcdf-dev
       - gfortran
-      - clang-5.0
       - wget
       #- lftp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,12 @@ addons:
 
 install:
   # Fetch Icepack-specific dataset
-  #- "wget ftp://ftp.cgd.ucar.edu/archive/Model-Data/CICE/Icepack_data.tar.gz &&
-  #tar xvfz Icepack_data.tar.gz -C ~"
+  - "wget ftp://ftp.cgd.ucar.edu/archive/Model-Data/CICE/Icepack_data.tar.gz &&
+    tar xvfz Icepack_data.tar.gz -C ~"
 
   # Mirror entire data folder
   #- "lftp ftp://anonymous:travis@travis-ci.org@ftp.cgd.ucar.edu 
   #-e 'mirror /archive/Model-Data/CICE/ ~/ICEPACK_INPUTDATA; quit'"
-
 
 script:
   - "./icepack.setup --suite travis_suite --testid travisCItest 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,9 @@ script:
 notifications:
   email: false
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 after_failure:
   - "for runlog in $TRAVIS_BUILD_DIR/travis_suite.travisCItest/*.travisCItest/logs/icepack.runlog.*; do
     echo \"### Contents of $runlog ###\" && cat $runlog; done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - libnetcdf-dev
       - gfortran
       - wget
+      - curl
       #- lftp
 
 install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Overview
 [![Build Status](https://travis-ci.org/CICE-Consortium/Icepack.svg?branch=master)](https://travis-ci.org/CICE-Consortium/Icepack)
 [![Documentation Status](https://readthedocs.org/projects/cice-consortium-icepack/badge/?version=master)](http://cice-consortium-icepack.readthedocs.io/en/master/?badge=master)
+[![codecov.io](http://codecov.io/github/CICE-Consortium/Icepack/coverage.svg?branch=master)](http://codecov.io/github/CICE-Consortium/Icepack?branch=master)
 
 This repository contains files describing the column physics of the sea ice model CICE, which is now maintained by the CICE Consortium.  For testing purposes and guidance for including Icepack in other sea ice host models, this repository also includes a driver and basic test suite.
 

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -4,17 +4,17 @@
 
 CPP        := cpp
 CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -fp-model precise   -xHost -coverage -g
-LDFLAGS    += -fprofile-arcs -g
+CFLAGS     := -c -O0 -fp-model precise   -xHost -coverage -g
+LDFLAGS    += -ftest-coverage -fprofile-arcs -g
 
 FIXEDFLAGS := -132
-FFLAGS     :=  -O2 -ffree-line-length-none -fconvert=big-endian -finit-real=nan -fprofile-arcs -ftest-coverage
+FFLAGS     :=  -O0 -ffree-line-length-none -fconvert=big-endian -finit-real=nan -fprofile-arcs -ftest-coverage -g
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
     FFLAGS     += -O0 -g -Wextra -fbacktrace -fbounds-check -ffpe-trap=zero,overflow
 else
-    FFLAGS     += -O2
+    FFLAGS     += -O0
 endif
 
 FC := gfortran

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -5,6 +5,7 @@
 CPP        := cpp
 CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${ICE_CPPDEFS}
 CFLAGS     := -c -O2 -fp-model precise   -xHost -coverage
+LDFLAGS    += -fprofile-arcs
 
 FIXEDFLAGS := -132
 FFLAGS     :=  -O2 -ffree-line-length-none -fconvert=big-endian -finit-real=nan -fprofile-arcs -ftest-coverage

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -4,8 +4,8 @@
 
 CPP        := cpp
 CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -fp-model precise   -xHost -coverage
-LDFLAGS    += -fprofile-arcs
+CFLAGS     := -c -O2 -fp-model precise   -xHost -coverage -g
+LDFLAGS    += -fprofile-arcs -g
 
 FIXEDFLAGS := -132
 FFLAGS     :=  -O2 -ffree-line-length-none -fconvert=big-endian -finit-real=nan -fprofile-arcs -ftest-coverage

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -2,9 +2,9 @@
 # Makefile macros for Travis-CI - gfortran and llvm (clang) compilers
 #==============================================================================
 
-CPP        := clang-cpp
+CPP        := cpp
 CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -fp-model precise   -xHost
+CFLAGS     := -c -O2 -fp-model precise   -xHost -coverage
 
 FIXEDFLAGS := -132
 FFLAGS     :=  -O2 -ffree-line-length-none -fconvert=big-endian -finit-real=nan -fprofile-arcs -ftest-coverage
@@ -30,7 +30,7 @@ ifeq ($(ICE_IOTYPE), netcdf)
     INCLDIR := $(INCLDIR) -I$(NETCDF_PATH)/include
     LIB_NETCDF := $(NETCDF_PATH)/lib
     LIB_PNETCDF := 
-    SLIBS   := -L$(LIB_NETCDF) -lnetcdf 
+    SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
 else
     SLIBS   := 
 endif

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -7,7 +7,7 @@ CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPR
 CFLAGS     := -c -O2 -fp-model precise   -xHost
 
 FIXEDFLAGS := -132
-FFLAGS     :=  -O2 -ffree-line-length-none -fconvert=big-endian -finit-real=nan
+FFLAGS     :=  -O2 -ffree-line-length-none -fconvert=big-endian -finit-real=nan -fprofile-arcs -ftest-coverage
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)


### PR DESCRIPTION
## Test-coverage reporting
This pull request introduces coverage metrics for `travis_suite`, and submits them to [codecov.io](https://codecov.io). See an example for Icepack [here](https://codecov.io/gh/anders-dc/Icepack/tree/77357589a040e2b2158b8ab4f89d2298294fe7bf/). The overview shows what lines of source code are "hit" by the test suite, and which are not. The coverage metrics are submitted to codecov.io if the build succeeds.

In order to obtain accurate testing metrics, the Travis runs run without optimizations (flag `-O0`). Therefore, the test suite may take slightly longer to complete from now on.

## Steps required for CICE-Consortium
Someone with ownership of the Github user [CICE-Consortium](https://github.com/CICE-Consortium) needs to [sign up to codecov.io with the Github user](https://codecov.io/login/gh). Afterwards, this person needs to enable the Icepack repository on the codecov page. You may want to enable the CICE repository right away as well. We do not need the token that is generated.

## Other changes in this PR
I transitioned from clang to GCC for linking purposes on Travis-CI (like I did with CICE). This should have no practical implications.

---
*Developer(s):* Anders Damsgaard, Princeton/NOAA-GFDL ([github.com/anders-dc](https://github.com/anders-dc), [adamsgaard.dk](https://adamsgaard.dk))

*Are the code changes bit for bit, different at roundoff level, or more substantial?* There are no changes to the underlying code.

*Is the documentation being updated with this PR? (Y/N)* No.

*If not, does the documentation need to be updated separately? (Y/N)* No.
