### PR TITLE
fix restarts for restore_ocn=T

### DIFF
--- a/configuration/driver/icedrv_flux.F90
+++ b/configuration/driver/icedrv_flux.F90
@@ -122,6 +122,7 @@
       real (kind=dbl_kind), dimension (nx), public :: &
          sss     , & ! sea surface salinity (ppt)
          sst     , & ! sea surface temperature (C)
+         sstdat  , & ! sea surface temperature (C) saved for restoring
          frzmlt  , & ! freezing/melting potential (W/m^2)
          frzmlt_init, & ! frzmlt used in current time step (W/m^2)
          Tf      , & ! freezing temperature (C)
@@ -463,6 +464,7 @@
       frzmlt (:) = c0              ! freezing/melting potential (W/m^2)
       sss    (:) = 34.0_dbl_kind   ! sea surface salinity (ppt)
       sst    (:) = -1.8_dbl_kind   ! sea surface temperature (C)
+      sstdat (:) = sst(:)          ! sea surface temperature (C)
 
       do i = 1, nx
          Tf (i) = icepack_liquidus_temperature(sss(i)) ! freezing temp (C)

--- a/configuration/driver/icedrv_forcing.F90
+++ b/configuration/driver/icedrv_forcing.F90
@@ -18,7 +18,7 @@
       use icedrv_system, only: icedrv_system_abort
       use icedrv_flux, only: zlvl, Tair, potT, rhoa, uatm, vatm, wind, &
          strax, stray, fsw, swvdr, swvdf, swidr, swidf, Qa, flw, frain, &
-         fsnow, sst, sss, uocn, vocn, qdp, hmix, Tf, opening, closing
+         fsnow, sst, sss, uocn, vocn, qdp, hmix, Tf, opening, closing, sstdat
 
       implicit none
       private
@@ -142,7 +142,6 @@
          frain_data(:) = frain(i)    ! rainfall rate (kg/m^2 s)
          fsnow_data(:) = fsnow(i)    ! snowfall rate (kg/m^2 s)
            qdp_data(:) = qdp  (i)    ! deep ocean heat flux (W/m^2)
-           sst_data(:) = sst  (i)    ! sea surface temperature
            sss_data(:) = sss  (i)    ! sea surface salinity
           uocn_data(:) = uocn (i)    ! ocean current components (m/s)
           vocn_data(:) = vocn (i)
@@ -160,6 +159,9 @@
         else
           trest = real(trestore,kind=dbl_kind) * secday ! seconds
         end if
+        sst_data(:) = sstdat(i)    ! default may be overwritten below
+      else
+        sst_data(:) = sst   (i)    ! default or restart value if not restoring
       endif
 
       if (trim(ocn_data_type(1:5)) == 'ISPOL') call ocn_ISPOL
@@ -175,6 +177,7 @@
                             swvdr_data,    swvdf_data,    &
                             swidr_data,    swidf_data,    &
                             potT_data)
+
       end subroutine init_forcing
 
 !=======================================================================

--- a/configuration/scripts/tests/base_suite.ts
+++ b/configuration/scripts/tests/base_suite.ts
@@ -22,6 +22,6 @@ restart        col     1x1        thermo1
 restart        col     1x1        swccsm3
 restart        col     1x1        alt01
 restart        col     1x1        alt02
-#restart        col     1x1        alt03
-#restart        col     1x1        alt04
+restart        col     1x1        alt03
+restart        col     1x1        alt04
 restart        col     1x1        dyn


### PR DESCRIPTION
Fixes the restart failures for the alt03 and alt04 tests, which were associated with sst restoring.  See also issue #198.

- Developer(s):  E. Hunke

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial?  BFB except for alt03 and alt04 restarts, which were not BFB before and now are BFB

- Is the documentation being updated with this PR? (Y/N)  N
If not, does the documentation need to be updated separately at a later time? (Y/N)  N
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-icepack/.  

- Other Relevant Details:
Turned on the alt03 and alt04 restart tests in base_suite.
Test results:  https://github.com/CICE-Consortium/Test-Results/wiki/v1.0.0.d0003.1c384b3565.pinto.intel.180516.023220