### PR TITLE
CMIP changes

### DIFF
--- a/columnphysics/icepack_flux.F90
+++ b/columnphysics/icepack_flux.F90
@@ -32,18 +32,22 @@
                                strairxn, strairyn,   &
                                Cdn_atm_ratio_n,      &
                                fsurfn,   fcondtopn,  &  
+                               fcondbotn,            &
                                fsensn,   flatn,      & 
                                fswabsn,  flwoutn,    &
                                evapn,                &
+                               evapsn,   evapin,     &
                                Trefn,    Qrefn,      &
                                freshn,   fsaltn,     &
                                fhocnn,   fswthrun,   &
                                strairxT, strairyT,   &  
                                Cdn_atm_ratio,        &
                                fsurf,    fcondtop,   &
+                               fcondbot,             &
                                fsens,    flat,       & 
                                fswabs,   flwout,     &
                                evap,                 & 
+                               evaps,    evapi,      &
                                Tref,     Qref,       &
                                fresh,    fsalt,      & 
                                fhocn,    fswthru,    &
@@ -62,11 +66,14 @@
           Cdn_atm_ratio_n, & ! ratio of total drag over neutral drag  
           fsurfn  , & ! net heat flux to top surface    (W/m**2)
           fcondtopn,& ! downward cond flux at top sfc   (W/m**2)
+          fcondbotn,& ! downward cond flux at bottom sfc   (W/m**2)
           fsensn  , & ! sensible heat flx               (W/m**2)
           flatn   , & ! latent   heat flx               (W/m**2)
           fswabsn , & ! shortwave absorbed heat flx     (W/m**2)
           flwoutn , & ! upwd lw emitted heat flx        (W/m**2)
           evapn   , & ! evaporation                     (kg/m2/s)
+          evapsn  , & ! evaporation over snow           (kg/m2/s)
+          evapin  , & ! evaporation over ice            (kg/m2/s)
           Trefn   , & ! air tmp reference level         (K)
           Qrefn   , & ! air sp hum reference level      (kg/kg)
           freshn  , & ! fresh water flux to ocean       (kg/m2/s)
@@ -89,11 +96,14 @@
           Cdn_atm_ratio, & ! ratio of total drag over neutral drag
           fsurf   , & ! net heat flux to top surface    (W/m**2)
           fcondtop, & ! downward cond flux at top sfc   (W/m**2)
+          fcondbot, & ! downward cond flux at bottom sfc   (W/m**2)
           fsens   , & ! sensible heat flx               (W/m**2)
           flat    , & ! latent   heat flx               (W/m**2)
           fswabs  , & ! shortwave absorbed heat flx     (W/m**2)
           flwout  , & ! upwd lw emitted heat flx        (W/m**2)
           evap    , & ! evaporation                     (kg/m2/s)
+          evaps   , & ! evaporation over snow           (kg/m2/s)
+          evapi   , & ! evaporation over ice            (kg/m2/s)
           Tref    , & ! air tmp reference level         (K)
           Qref    , & ! air sp hum reference level      (kg/kg)
           fresh   , & ! fresh water flux to ocean       (kg/m2/s)
@@ -126,12 +136,15 @@
                       Cdn_atm_ratio_n   * aicen
       fsurf      = fsurf    + fsurfn    * aicen
       fcondtop   = fcondtop + fcondtopn * aicen 
+      fcondbot   = fcondbot + fcondbotn * aicen 
       fsens      = fsens    + fsensn    * aicen
       flat       = flat     + flatn     * aicen
       fswabs     = fswabs   + fswabsn   * aicen
       flwout     = flwout   &
            + (flwoutn - (c1-emissivity)*flw) * aicen
       evap       = evap     + evapn     * aicen
+      evaps      = evaps    + evapsn    * aicen
+      evapi      = evapi    + evapin    * aicen
       Tref       = Tref     + Trefn     * aicen
       Qref       = Qref     + Qrefn     * aicen
 

--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -3482,7 +3482,8 @@
          Tsfc   , & ! surface temperature 
          hs0        ! snow depth for transition to bare sea ice (m)
 
-      real (kind=dbl_kind), intent(out) :: &
+!    real (kind=dbl_kind), intent(inout) :: &
+     real (kind=dbl_kind), intent(out) :: &
          fs     , & ! horizontal coverage of snow
          hs         ! snow depth
 

--- a/columnphysics/icepack_therm_mushy.F90
+++ b/columnphysics/icepack_therm_mushy.F90
@@ -1029,7 +1029,7 @@ contains
          hilyr  , & ! ice layer thickness (m)
          hslyr      ! snow layer thickness (m)
 
-    real(kind=dbl_kind), dimension(:), intent(out) :: &
+    real(kind=dbl_kind), dimension(:), intent(inout) :: &
          zTin   , & ! ice layer temperature (C)
          Sbr    , & ! ice layer brine salinity (ppt)
          phi    , & ! ice layer liquid fraction
@@ -1971,7 +1971,7 @@ contains
     real(kind=dbl_kind), dimension(:), intent(inout) :: &
          zTin             ! ice layer temperature (C)
 
-    real(kind=dbl_kind), dimension(:), intent(out) :: &
+    real(kind=dbl_kind), dimension(:), intent(inout) :: &
          zTsn             ! snow layer temperature (C)
 
     real(kind=dbl_kind), dimension(nilyr+nslyr+1) :: &

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -84,7 +84,7 @@
                                   Qa,          rhoa,      &
                                   fsnow,       fpond,     &
                                   fbot,        Tbot,      &
-                                  Tsnic,       sss,       &
+                                  Tsnice,       sss,       &
                                   lhcoef,      shcoef,    &
                                   fswsfc,      fswint,    &
                                   Sswabs,      Iswabs,    &
@@ -183,7 +183,7 @@
       ! diagnostic fields
       real (kind=dbl_kind), &
          intent(inout):: &
-         Tsnic    , & ! snow ice interface temperature (deg C)
+         Tsnice    , & ! snow ice interface temperature (deg C)
          meltt    , & ! top ice melt             (m/step-->cm/day) 
          melts    , & ! snow melt                (m/step-->cm/day) 
          meltb    , & ! basal ice melt           (m/step-->cm/day) 
@@ -253,6 +253,8 @@
       congel  = c0
       snoice  = c0
       dsnow   = c0
+      zTsn(:) = c0
+      zTin(:) = c0
 
       if (calc_Tsfc) then
          fsensn  = c0
@@ -370,7 +372,14 @@
          einter = einter + hilyr * zqin(k)
       enddo ! k
 
-      Tsnic = (hslyr*zTsn(nslyr) + hilyr*zTin(1)) / (hslyr+hilyr)
+      Tsnice = c0
+      if ((hslyr+hilyr) > puny) then
+         if (hslyr > puny) then
+            Tsnice = (hslyr*zTsn(nslyr) + hilyr*zTin(1)) / (hslyr+hilyr)
+         else
+            Tsnice = Tsf
+         endif
+      endif
 
       if (icepack_warnings_aborted(subname)) return
 
@@ -2041,7 +2050,7 @@
                                     sss         , Tf          , &
                                     strocnxT    , strocnyT    , &
                                     fbot        ,               &
-                                    Tbot        , Tsnic       , &
+                                    Tbot        , Tsnice       , &
                                     frzmlt      , rside       , &
                                     fsnow       , frain       , &
                                     fpond       ,               &
@@ -2152,12 +2161,12 @@
          strocnxT    , & ! ice-ocean stress, x-direction
          strocnyT    , & ! ice-ocean stress, y-direction
          fbot        , & ! ice-ocean heat flux at bottom surface (W/m^2)
-         Tbot        , & ! ice bottom surface temperature (deg C)
-         Tsnic       , & ! ice snow interface temperature (deg C)
          frzmlt      , & ! freezing/melting potential (W/m^2)
          rside       , & ! fraction of ice that melts laterally
          sst         , & ! sea surface temperature (C)
          Tf          , & ! freezing temperature (C)
+         Tbot        , & ! ice bottom surface temperature (deg C)
+         Tsnice       , & ! snow ice interface temperature (deg C)
          sss         , & ! sea surface salinity (ppt)
          meltt       , & ! top ice melt             (m/step-->cm/day)
          melts       , & ! snow melt                (m/step-->cm/day)
@@ -2396,7 +2405,7 @@
                                  Qa,           rhoa,         &
                                  fsnow,        fpond,        &
                                  fbot,         Tbot,         &
-                                 Tsnic,        sss,          &
+                                 Tsnice,        sss,          &
                                  lhcoef,       shcoef,       &
                                  fswsfcn  (n), fswintn  (n), &
                                  Sswabsn(:,n), Iswabsn(:,n), &

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -2158,8 +2158,6 @@
          rside       , & ! fraction of ice that melts laterally
          sst         , & ! sea surface temperature (C)
          Tf          , & ! freezing temperature (C)
-         Tbot        , & ! ice bottom surface temperature (deg C)
-         Tsnic       , & ! snow ice interface temperature (deg C)
          sss         , & ! sea surface salinity (ppt)
          meltt       , & ! top ice melt             (m/step-->cm/day)
          melts       , & ! snow melt                (m/step-->cm/day)

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -2020,6 +2020,7 @@
                                     sss         , Tf          , &
                                     strocnxT    , strocnyT    , &
                                     fbot        ,               &
+                                    Tbot        , Tsnic       , &
                                     frzmlt      , rside       , &
                                     fsnow       , frain       , &
                                     fpond       ,               &
@@ -2125,6 +2126,8 @@
          strocnxT    , & ! ice-ocean stress, x-direction
          strocnyT    , & ! ice-ocean stress, y-direction
          fbot        , & ! ice-ocean heat flux at bottom surface (W/m^2)
+         Tbot        , & ! ice bottom surface temperature (deg C)
+         Tsnic       , & ! ice snow interface temperature (deg C)
          frzmlt      , & ! freezing/melting potential (W/m^2)
          rside       , & ! fraction of ice that melts laterally
          sst         , & ! sea surface temperature (C)
@@ -2206,7 +2209,6 @@
          Trefn       , & ! air tmp reference level                (K)
          Urefn       , & ! air speed reference level            (m/s)
          Qrefn       , & ! air sp hum reference level         (kg/kg)
-         Tbot        , & ! ice bottom surface temperature (deg C)
          shcoef      , & ! transfer coefficient for sensible heat
          lhcoef      , & ! transfer coefficient for latent heat
          rfrac           ! water fraction retained for melt ponds

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -84,13 +84,15 @@
                                   Qa,          rhoa,      &
                                   fsnow,       fpond,     &
                                   fbot,        Tbot,      &
-                                  sss,                    &
+                                  Tsnic,       sss,       &
                                   lhcoef,      shcoef,    &
                                   fswsfc,      fswint,    &
                                   Sswabs,      Iswabs,    &
                                   fsurfn,      fcondtopn, &
+                                  fcondbotn,              &
                                   fsensn,      flatn,     &
                                   flwoutn,     evapn,     &
+                                  evapsn,      evapin,    &
                                   freshn,      fsaltn,    &
                                   fhocnn,      meltt,     &
                                   melts,       meltb,     &
@@ -160,14 +162,17 @@
       ! coupler fluxes to atmosphere
       real (kind=dbl_kind), intent(out):: &
          flwoutn , & ! outgoing longwave radiation (W/m^2) 
-         evapn       ! evaporative water flux (kg/m^2/s) 
+         evapn   , & ! evaporative water flux (kg/m^2/s) 
+         evapsn  , & ! evaporative water flux over snow (kg/m^2/s) 
+         evapin      ! evaporative water flux over ice (kg/m^2/s) 
 
       ! Note: these are intent out if calc_Tsfc = T, otherwise intent in
       real (kind=dbl_kind), intent(inout):: &
          fsensn   , & ! sensible heat flux (W/m^2) 
          flatn    , & ! latent heat flux   (W/m^2) 
          fsurfn   , & ! net flux to top surface, excluding fcondtopn
-         fcondtopn    ! downward cond flux at top surface (W m-2)
+         fcondtopn, & ! downward cond flux at top surface (W m-2)
+         fcondbotn    ! downward cond flux at bottom surface (W m-2)
 
       ! coupler fluxes to ocean
       real (kind=dbl_kind), intent(out):: &
@@ -178,6 +183,7 @@
       ! diagnostic fields
       real (kind=dbl_kind), &
          intent(inout):: &
+         Tsnic    , & ! snow ice interface temperature (deg C)
          meltt    , & ! top ice melt             (m/step-->cm/day) 
          melts    , & ! snow melt                (m/step-->cm/day) 
          meltb    , & ! basal ice melt           (m/step-->cm/day) 
@@ -219,7 +225,6 @@
 ! other 2D flux and energy variables
 
       real (kind=dbl_kind) :: &
-         fcondbot    , & ! downward cond flux at bottom surface (W m-2)
          einit       , & ! initial energy of melting (J m-2)
          efinal      , & ! final energy of melting (J m-2)
          einter          ! intermediate energy
@@ -235,6 +240,8 @@
 
       flwoutn = c0
       evapn   = c0
+      evapsn   = c0
+      evapin   = c0
       freshn  = c0
       fsaltn  = c0
       fhocnn  = c0
@@ -298,7 +305,7 @@
                                               sss,                  &
                                               fsensn,    flatn,     &
                                               flwoutn,   fsurfn,    &
-                                              fcondtopn, fcondbot,  &
+                                              fcondtopn, fcondbotn,  &
                                               fadvocn,   snoice)
             if (icepack_warnings_aborted(subname)) return
 
@@ -318,7 +325,7 @@
                                      Tsf,       Tbot,      &
                                      fsensn,    flatn,     &
                                      flwoutn,   fsurfn,    &
-                                     fcondtopn, fcondbot,  &
+                                     fcondtopn, fcondbotn,  &
                                      einit                 )
             if (icepack_warnings_aborted(subname)) return
 
@@ -337,7 +344,7 @@
                                        Tsf,       Tbot,     &
                                        fsensn,    flatn,    &
                                        flwoutn,   fsurfn,   &
-                                       fcondtopn, fcondbot  )
+                                       fcondtopn, fcondbotn  )
             if (icepack_warnings_aborted(subname)) return
 
          else
@@ -347,7 +354,7 @@
             ! fcondtop is set in call to set_sfcflux in step_therm1
             !------------------------------------------------------------
 
-            fcondbot  = fcondtopn   ! zero layer         
+            fcondbotn  = fcondtopn   ! zero layer         
       
          endif      ! calc_Tsfc
 
@@ -362,6 +369,8 @@
       do k = 1, nilyr
          einter = einter + hilyr * zqin(k)
       enddo ! k
+
+      Tsnic = (hslyr*zTsn(nslyr) + hilyr*zTin(1)) / (hslyr+hilyr)
 
       if (icepack_warnings_aborted(subname)) return
 
@@ -379,9 +388,10 @@
                              zqin,        zqsn,      &
                              fbot,        Tbot,      &
                              flatn,       fsurfn,    &
-                             fcondtopn,   fcondbot,  &
+                             fcondtopn,   fcondbotn,  &
                              fsnow,       hsn_new,   &
                              fhocnn,      evapn,     &
+                             evapsn,      evapin,    &
                              meltt,       melts,     &
                              meltb,       &
                              congel,      snoice,    &
@@ -400,7 +410,7 @@
                                       fhocnn,    fswint,   &
                                       fsnow,     einit,    &
                                       einter,    efinal,   &
-                                      fcondtopn, fcondbot, &
+                                      fcondtopn, fcondbotn, &
                                       fadvocn,   fbot      )
       if (icepack_warnings_aborted(subname)) return
 
@@ -1001,9 +1011,10 @@
                                     zqin,      zqsn,     &
                                     fbot,      Tbot,     &
                                     flatn,     fsurfn,   &
-                                    fcondtopn, fcondbot, &
+                                    fcondtopn, fcondbotn, &
                                     fsnow,     hsn_new,  &
                                     fhocnn,    evapn,    &
+                                    evapsn,    evapin,   &
                                     meltt,     melts,    &
                                     meltb,     &
                                     congel,    snoice,   &  
@@ -1028,7 +1039,7 @@
          fcondtopn       ! downward cond flux at top surface (W m-2)
 
       real (kind=dbl_kind), intent(inout) :: &
-         fcondbot        ! downward cond flux at bottom surface (W m-2)
+         fcondbotn       ! downward cond flux at bottom surface (W m-2)
 
       real (kind=dbl_kind), dimension (:), intent(inout) :: &
          zqin        , & ! ice layer enthalpy (J m-3)
@@ -1058,7 +1069,9 @@
 
       real (kind=dbl_kind), intent(out):: &
          fhocnn      , & ! fbot, corrected for any surplus energy (W m-2)
-         evapn           ! ice/snow mass sublimated/condensed (kg m-2 s-1)
+         evapn       , & ! ice/snow mass sublimated/condensed (kg m-2 s-1)
+         evapsn      , & ! ice/snow mass sublimated/condensed over snow (kg m-2 s-1)
+         evapin          ! ice/snow mass sublimated/condensed over ice (kg m-2 s-1)
 
       real (kind=dbl_kind), intent(out):: &
          hsn_new         ! thickness of new snow (m)
@@ -1191,7 +1204,7 @@
       wk1 = (fsurfn - fcondtopn) * dt
       etop_mlt = max(wk1, c0)           ! etop_mlt > 0
 
-      wk1 = (fcondbot - fbot) * dt
+      wk1 = (fcondbotn - fbot) * dt
       ebot_mlt = max(wk1, c0)           ! ebot_mlt > 0
       ebot_gro = min(wk1, c0)           ! ebot_gro < 0
 
@@ -1203,15 +1216,19 @@
       !--------------------------------------------------------------
 
       evapn = c0          ! initialize
+      evapsn = c0          ! initialize
+      evapin = c0          ! initialize
 
       if (hsn > puny) then    ! add snow with enthalpy zqsn(1)
          dhs = econ / (zqsn(1) - rhos*Lvap) ! econ < 0, dhs > 0
          dzs(1) = dzs(1) + dhs
          evapn = evapn + dhs*rhos
+         evapsn = evapsn + dhs*rhos
       else                        ! add ice with enthalpy zqin(1)
          dhi = econ / (qm(1) - rhoi*Lvap) ! econ < 0, dhi > 0
          dzi(1) = dzi(1) + dhi
          evapn = evapn + dhi*rhoi
+         evapin = evapin + dhi*rhoi
          ! enthalpy of melt water
          emlt_atm = emlt_atm - qmlt(1) * dhi 
       endif
@@ -1305,6 +1322,7 @@
          esub = esub - dhs*qsub
          esub = max(esub, c0)   ! in case of roundoff error
          evapn = evapn + dhs*rhos
+         evapsn = evapsn + dhs*rhos
 
          !--------------------------------------------------------------
          ! Melt snow (top)
@@ -1334,6 +1352,7 @@
          esub = esub - dhi*qsub
          esub = max(esub, c0)
          evapn = evapn + dhi*rhoi
+         evapin = evapin + dhi*rhoi
          emlt_ocn = emlt_ocn - qmlt(k) * dhi 
 
          !--------------------------------------------------------------
@@ -1572,6 +1591,8 @@
 
       efinal = -evapn*Lvap
       evapn =  evapn/dt
+      evapsn =  evapsn/dt
+      evapin =  evapin/dt
 
       do k = 1, nslyr
          efinal = efinal + hslyr*zqsn(k)
@@ -1799,7 +1820,7 @@
                                             fsnow,              &
                                             einit,    einter,   &
                                             efinal,             &
-                                            fcondtopn,fcondbot, &
+                                            fcondtopn,fcondbotn, &
                                             fadvocn,  fbot      )
 
       real (kind=dbl_kind), intent(in) :: &
@@ -1819,7 +1840,7 @@
          einit       , & ! initial energy of melting (J m-2)
          einter      , & ! intermediate energy of melting (J m-2)
          efinal      , & ! final energy of melting (J m-2)
-         fcondbot
+         fcondbotn
 
       ! local variables
 
@@ -1868,7 +1889,7 @@
          call icepack_warnings_add(warnstr)
          write(warnstr,*) subname, 'fbot,fcondbot:'
          call icepack_warnings_add(warnstr)
-         write(warnstr,*) subname, fbot,fcondbot
+         write(warnstr,*) subname, fbot,fcondbotn
          call icepack_warnings_add(warnstr)
 
          !         if (ktherm == 2) then
@@ -1881,10 +1902,10 @@
               einter-einit
          call icepack_warnings_add(warnstr)
          write(warnstr,*) subname, 'Conduction Error =', (einter-einit) &
-              - (fcondtopn*dt - fcondbot*dt + fswint*dt)
+              - (fcondtopn*dt - fcondbotn*dt + fswint*dt)
          call icepack_warnings_add(warnstr)
          write(warnstr,*) subname, 'Melt/Growth Error =', (einter-einit) &
-              + ferr*dt - (fcondtopn*dt - fcondbot*dt + fswint*dt)
+              + ferr*dt - (fcondtopn*dt - fcondbotn*dt + fswint*dt)
          call icepack_warnings_add(warnstr)
          write(warnstr,*) subname, 'Advection Error =', fadvocn*dt
          call icepack_warnings_add(warnstr)
@@ -2026,6 +2047,7 @@
                                     fpond       ,               &
                                     fsurf       , fsurfn      , &
                                     fcondtop    , fcondtopn   , &
+                                    fcondbot    , fcondbotn   , &
                                     fswsfcn     , fswintn     , &
                                     fswthrun    , fswabs      , &
                                     flwout      ,               &
@@ -2034,6 +2056,7 @@
                                     fsens       , fsensn      , &
                                     flat        , flatn       , &
                                     evap        ,               &
+                                    evaps       , evapi       , &
                                     fresh       , fsalt       , &
                                     fhocn       , fswthru     , &
                                     flatn_f     , fsensn_f    , &
@@ -2092,12 +2115,15 @@
          fswthru     , & ! shortwave penetrating to ocean (W/m^2)
          fsurf       , & ! net surface heat flux (excluding fcondtop)(W/m^2)
          fcondtop    , & ! top surface conductive flux        (W/m^2)
+         fcondbot    , & ! bottom surface conductive flux     (W/m^2)
          fsens       , & ! sensible heat flux (W/m^2)
          flat        , & ! latent heat flux   (W/m^2)
          fswabs      , & ! shortwave flux absorbed in ice and ocean (W/m^2)
          flw         , & ! incoming longwave radiation (W/m^2)
          flwout      , & ! outgoing longwave radiation (W/m^2)
          evap        , & ! evaporative water flux (kg/m^2/s)
+         evaps       , & ! evaporative water flux over snow (kg/m^2/s)
+         evapi       , & ! evaporative water flux over ice (kg/m^2/s)
          congel      , & ! basal ice growth         (m/step-->cm/day)
          snoice      , & ! snow-ice formation       (m/step-->cm/day)
          Tref        , & ! 2m atm reference temperature (K)
@@ -2132,6 +2158,8 @@
          rside       , & ! fraction of ice that melts laterally
          sst         , & ! sea surface temperature (C)
          Tf          , & ! freezing temperature (C)
+         Tbot        , & ! ice bottom surface temperature (deg C)
+         Tsnic       , & ! snow ice interface temperature (deg C)
          sss         , & ! sea surface salinity (ppt)
          meltt       , & ! top ice melt             (m/step-->cm/day)
          melts       , & ! snow melt                (m/step-->cm/day)
@@ -2156,6 +2184,7 @@
          FY          , & ! area-weighted first-year ice area
          fsurfn      , & ! net flux to top surface, excluding fcondtop
          fcondtopn   , & ! downward cond flux at top surface (W m-2)
+         fcondbotn   , & ! downward cond flux at bottom surface (W m-2)
          flatn       , & ! latent heat flux (W m-2)
          fsensn      , & ! sensible heat flux (W m-2)
          fsurfn_f    , & ! net flux to top surface, excluding fcondtop
@@ -2200,6 +2229,8 @@
          fswabsn     , & ! shortwave absorbed by ice          (W/m^2)
          flwoutn     , & ! upward LW at surface               (W/m^2)
          evapn       , & ! flux of vapor, atmos to ice   (kg m-2 s-1)
+         evapsn      , & ! flux of vapor, atmos to ice over snow  (kg m-2 s-1)
+         evapin      , & ! flux of vapor, atmos to ice over ice  (kg m-2 s-1)
          freshn      , & ! flux of water, ice to ocean     (kg/m^2/s)
          fsaltn      , & ! flux of salt, ice to ocean      (kg/m^2/s)
          fhocnn      , & ! fbot corrected for leftover energy (W/m^2)
@@ -2367,13 +2398,15 @@
                                  Qa,           rhoa,         &
                                  fsnow,        fpond,        &
                                  fbot,         Tbot,         &
-                                 sss,                        &
+                                 Tsnic,        sss,          &
                                  lhcoef,       shcoef,       &
                                  fswsfcn  (n), fswintn  (n), &
                                  Sswabsn(:,n), Iswabsn(:,n), &
                                  fsurfn   (n), fcondtopn(n), &
+                                 fcondbotn(n),               &
                                  fsensn   (n), flatn    (n), &
                                  flwoutn,      evapn,        &
+                                 evapsn,       evapin,       &
                                  freshn,       fsaltn,       &
                                  fhocnn,                     &
                                  melttn   (n), meltsn   (n), &
@@ -2489,18 +2522,22 @@
                                strairxn,   strairyn,     &
                                Cdn_atm_ratio_n,          &
                                fsurfn(n),  fcondtopn(n), &
+                               fcondbotn(n),             &
                                fsensn(n),  flatn(n),     &
                                fswabsn,    flwoutn,      &
                                evapn,                    &
+                               evapsn,     evapin,       &
                                Trefn,      Qrefn,        &
                                freshn,     fsaltn,       &
                                fhocnn,     fswthrun(n),  &
                                strairxT,   strairyT,     &
                                Cdn_atm_ratio,            &
                                fsurf,      fcondtop,     &
+                               fcondbot,                 &
                                fsens,      flat,         &
                                fswabs,     flwout,       &
                                evap,                     &
+                               evaps,      evapi,        &
                                Tref,       Qref,         &
                                fresh,      fsalt,        &
                                fhocn,      fswthru,      &

--- a/configuration/driver/icedrv_flux.F90
+++ b/configuration/driver/icedrv_flux.F90
@@ -219,6 +219,8 @@
          fsurf , & ! net surface heat flux (excluding fcondtop)(W/m^2)
          fcondtop,&! top surface conductive flux        (W/m^2)
          fbot,   & ! heat flux at bottom surface of ice (excluding excess) (W/m^2)
+         Tbot,   & ! temperature at bottom surface of ice (deg C)
+         Tsnic,  & ! temperature at snow ice interface (deg C)
          congel, & ! basal ice growth         (m/step-->cm/day)
          frazil, & ! frazil ice growth        (m/step-->cm/day)
          snoice, & ! snow-ice formation       (m/step-->cm/day)

--- a/configuration/driver/icedrv_flux.F90
+++ b/configuration/driver/icedrv_flux.F90
@@ -141,7 +141,9 @@
          Tref    , & ! 2m atm reference temperature (K)
          Qref    , & ! 2m atm reference spec humidity (kg/kg)
          Uref    , & ! 10m atm reference wind speed (m/s)
-         evap        ! evaporative water flux (kg/m^2/s)
+         evap    , & ! evaporative water flux (kg/m^2/s)
+         evaps   , & ! evaporative water flux over snow (kg/m^2/s)
+         evapi       ! evaporative water flux over ice (kg/m^2/s)
 
        ! albedos aggregated over categories (if calc_Tsfc)
       real (kind=dbl_kind), dimension(nx), public :: &
@@ -493,6 +495,8 @@
       flwout  (:) = -stefan_boltzmann*Tffresh**4   
                      ! in case atm model diagnoses Tsfc from flwout
       evap    (:) = c0
+      evaps   (:) = c0
+      evapi   (:) = c0
       Tref    (:) = c0
       Qref    (:) = c0
       Uref    (:) = c0
@@ -560,6 +564,8 @@
       fswabs  (:) = c0
       flwout  (:) = c0
       evap    (:) = c0
+      evaps   (:) = c0
+      evapi   (:) = c0
       Tref    (:) = c0
       Qref    (:) = c0
       Uref    (:) = c0

--- a/configuration/driver/icedrv_flux.F90
+++ b/configuration/driver/icedrv_flux.F90
@@ -223,7 +223,7 @@
          fcondbot,&! bottom surface conductive flux        (W/m^2)
          fbot,   & ! heat flux at bottom surface of ice (excluding excess) (W/m^2)
          Tbot,   & ! Temperature at bottom surface of ice (deg C)
-         Tsnic,  & ! Temperature at snow ice interface (deg C)
+         Tsnice,  & ! Temperature at snow ice interface (deg C)
          congel, & ! basal ice growth         (m/step-->cm/day)
          frazil, & ! frazil ice growth        (m/step-->cm/day)
          snoice, & ! snow-ice formation       (m/step-->cm/day)

--- a/configuration/driver/icedrv_flux.F90
+++ b/configuration/driver/icedrv_flux.F90
@@ -218,9 +218,10 @@
       real (kind=dbl_kind), dimension (nx), public :: &
          fsurf , & ! net surface heat flux (excluding fcondtop)(W/m^2)
          fcondtop,&! top surface conductive flux        (W/m^2)
+         fcondbot,&! bottom surface conductive flux        (W/m^2)
          fbot,   & ! heat flux at bottom surface of ice (excluding excess) (W/m^2)
-         Tbot,   & ! temperature at bottom surface of ice (deg C)
-         Tsnic,  & ! temperature at snow ice interface (deg C)
+         Tbot,   & ! Temperature at bottom surface of ice (deg C)
+         Tsnic,  & ! Temperature at snow ice interface (deg C)
          congel, & ! basal ice growth         (m/step-->cm/day)
          frazil, & ! frazil ice growth        (m/step-->cm/day)
          snoice, & ! snow-ice formation       (m/step-->cm/day)
@@ -240,6 +241,7 @@
          dimension (nx,ncat), public :: &
          fsurfn,   & ! category fsurf
          fcondtopn,& ! category fcondtop
+         fcondbotn,& ! category fcondbot
          fsensn,   & ! category sensible heat flux
          flatn       ! category latent heat flux
 
@@ -616,6 +618,7 @@
 
       fsurf  (:) = c0
       fcondtop(:)= c0
+      fcondbot(:)= c0
       congel (:) = c0
       frazil (:) = c0
       snoice (:) = c0
@@ -633,6 +636,7 @@
       endif
       fsurfn    (:,:) = c0
       fcondtopn (:,:) = c0
+      fcondbotn (:,:) = c0
       flatn     (:,:) = c0
       fsensn    (:,:) = c0
       fpond     (:) = c0

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -104,7 +104,7 @@
       use icedrv_arrays_column, only: fswsfcn, fswintn, fswthrun, Sswabsn, Iswabsn
       use icedrv_calendar, only: yday
       use icedrv_domain_size, only: ncat, nilyr, nslyr, n_aero, nx
-      use icedrv_flux, only: frzmlt, sst, Tf, strocnxT, strocnyT, rside, fbot, Tbot, Tsnic
+      use icedrv_flux, only: frzmlt, sst, Tf, strocnxT, strocnyT, rside, fbot, Tbot, Tsnice
       use icedrv_flux, only: meltsn, melttn, meltbn, congeln, snoicen, uatm, vatm
       use icedrv_flux, only: wind, rhoa, potT, Qa, zlvl, strax, stray, flatn
       use icedrv_flux, only: fsensn, fsurfn, fcondtopn, fcondbotn
@@ -264,7 +264,7 @@
             sss         (i), Tf          (i), &
             strocnxT    (i), strocnyT    (i), &
             fbot        (i),                  &
-            Tbot        (i), Tsnic       (i), &
+            Tbot        (i), Tsnice       (i), &
             frzmlt      (i), rside       (i), &
             fsnow       (i), frain       (i), &
             fpond       (i),                           &

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -107,10 +107,10 @@
       use icedrv_flux, only: frzmlt, sst, Tf, strocnxT, strocnyT, rside, fbot, Tbot, Tsnic
       use icedrv_flux, only: meltsn, melttn, meltbn, congeln, snoicen, uatm, vatm
       use icedrv_flux, only: wind, rhoa, potT, Qa, zlvl, strax, stray, flatn
-      use icedrv_flux, only: fsensn, fsurfn, fcondtopn
+      use icedrv_flux, only: fsensn, fsurfn, fcondtopn, fcondbotn
       use icedrv_flux, only: flw, fsnow, fpond, sss, mlt_onset, frz_onset
       use icedrv_flux, only: frain, Tair, strairxT, strairyT, fsurf
-      use icedrv_flux, only: fcondtop, fsens, fresh, fsalt, fhocn
+      use icedrv_flux, only: fcondtop, fcondbot, fsens, fresh, fsalt, fhocn
       use icedrv_flux, only: flat, fswabs, flwout, evap, evaps, evapi, Tref, Qref, Uref
       use icedrv_flux, only: fswthru, meltt, melts, meltb, congel, snoice
       use icedrv_flux, only: flatn_f, fsensn_f, fsurfn_f, fcondtopn_f

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -111,7 +111,7 @@
       use icedrv_flux, only: flw, fsnow, fpond, sss, mlt_onset, frz_onset
       use icedrv_flux, only: frain, Tair, strairxT, strairyT, fsurf
       use icedrv_flux, only: fcondtop, fsens, fresh, fsalt, fhocn
-      use icedrv_flux, only: flat, fswabs, flwout, evap, Tref, Qref, Uref
+      use icedrv_flux, only: flat, fswabs, flwout, evap, evaps, evapi, Tref, Qref, Uref
       use icedrv_flux, only: fswthru, meltt, melts, meltb, congel, snoice
       use icedrv_flux, only: flatn_f, fsensn_f, fsurfn_f, fcondtopn_f
       use icedrv_flux, only: dsnown, faero_atm, faero_ocn
@@ -263,13 +263,14 @@
             potT        (i), sst         (i), &
             sss         (i), Tf          (i), &
             strocnxT    (i), strocnyT    (i), &
-            fbot        (i),                           &
+            fbot        (i),                  &
             Tbot        (i), Tsnic       (i), &
             frzmlt      (i), rside       (i), &
             fsnow       (i), frain       (i), &
             fpond       (i),                           &
             fsurf       (i), fsurfn      (i,:), &
             fcondtop    (i), fcondtopn   (i,:), &
+            fcondbot    (i), fcondbotn   (i,:), &
             fswsfcn     (i,:), fswintn     (i,:), &
             fswthrun    (i,:), fswabs      (i), &
             flwout      (i),                           &
@@ -278,6 +279,7 @@
             fsens       (i), fsensn      (i,:), &
             flat        (i), flatn       (i,:), &
             evap        (i),                           &
+            evaps       (i), evapi       (i), &
             fresh       (i), fsalt       (i), &
             fhocn       (i), fswthru     (i), &
             flatn_f     (i,:), fsensn_f    (i,:), &

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -104,7 +104,7 @@
       use icedrv_arrays_column, only: fswsfcn, fswintn, fswthrun, Sswabsn, Iswabsn
       use icedrv_calendar, only: yday
       use icedrv_domain_size, only: ncat, nilyr, nslyr, n_aero, nx
-      use icedrv_flux, only: frzmlt, sst, Tf, strocnxT, strocnyT, rside, fbot
+      use icedrv_flux, only: frzmlt, sst, Tf, strocnxT, strocnyT, rside, fbot, Tbot, Tsnic
       use icedrv_flux, only: meltsn, melttn, meltbn, congeln, snoicen, uatm, vatm
       use icedrv_flux, only: wind, rhoa, potT, Qa, zlvl, strax, stray, flatn
       use icedrv_flux, only: fsensn, fsurfn, fcondtopn
@@ -264,6 +264,7 @@
             sss         (i), Tf          (i), &
             strocnxT    (i), strocnyT    (i), &
             fbot        (i),                           &
+            Tbot        (i), Tsnic       (i), &
             frzmlt      (i), rside       (i), &
             fsnow       (i), frain       (i), &
             fpond       (i),                           &


### PR DESCRIPTION
This PR is necessary for the CMIP changes (CICE Issue 93) and also add changes for the evaporation over snow and sea ice issue (CICE issue 97). The CICE related CMIP changes are coming in a future PR. Here is a short summary of what has changed:

1. fcondbot and fcondbotn are added so they can be shared with the CICE code.

2. Tbot is now shared with the driver and hence CICE.

3. A new diagnostic variable Tsnic has been added for the snow-ice interface temperature.

4. New variables evaps and evapi along with category versions have been added to keep track of evaporation over snow and bare ice separately.

- Developer(s): D. Bailey

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-icepack/.  

- Other Relevant Details:
