### PR TITLE
Add dump_last namelist feature and turn it on for smoke tests.

### DIFF
--- a/configuration/driver/icedrv_calendar.F90
+++ b/configuration/driver/icedrv_calendar.F90
@@ -88,6 +88,7 @@
          new_hour       , & ! new hour = .true.
          use_leap_years , & ! use leap year functionality if true
          write_ic       , & ! write initial condition now
+         dump_last      , & ! write restart at end
          force_restart_now  ! force a restart now
 
       character (len=1), public :: &
@@ -241,6 +242,7 @@
         end select
 
         if (force_restart_now) write_restart = 1
+        if (dump_last .and. istep == npt) write_restart = 1
       
       endif !  istep > 1
 

--- a/configuration/driver/icedrv_init.F90
+++ b/configuration/driver/icedrv_init.F90
@@ -58,7 +58,7 @@
       use icedrv_diagnostics, only: diag_file, nx_names
       use icedrv_domain_size, only: nilyr, nslyr, max_ntrcr, ncat, n_aero
       use icedrv_calendar, only: year_init, istep0
-      use icedrv_calendar, only: dumpfreq, diagfreq
+      use icedrv_calendar, only: dumpfreq, diagfreq, dump_last
       use icedrv_calendar, only: npt, dt, ndtd, days_per_year, use_leap_years
       use icedrv_restart_shared, only: restart, restart_dir, restart_file
       use icedrv_flux, only: update_ocn_f, l_mpond_fresh, cpl_bgc
@@ -112,7 +112,7 @@
 
       namelist /setup_nml/ &
         days_per_year,  use_leap_years, year_init,       istep0,        &
-        dt,             npt,            ndtd,                           &
+        dt,             npt,            ndtd,            dump_last,     &
         ice_ic,         restart,        restart_dir,     restart_file,  &
         dumpfreq,       diagfreq,       diag_file,       cpl_bgc
 
@@ -209,6 +209,7 @@
       diag_file = 'ice_diag' ! history file name prefix
       cpl_bgc = .false.      ! 
       dumpfreq='y'           ! restart frequency option
+      dump_last=.false.      ! restart at end of run
       restart = .false.      ! if true, read restart files for initialization
       restart_dir  = './'    ! write to executable dir for default
       restart_file = 'iced'  ! restart file name prefix
@@ -459,6 +460,7 @@
          write(nu_diag,1020) ' diagfreq                  = ', diagfreq
          write(nu_diag,1030) ' dumpfreq                  = ', &
                                trim(dumpfreq)
+         write(nu_diag,1010) ' dump_last                 = ', dump_last
          write(nu_diag,1010) ' restart                   = ', restart
          write(nu_diag,*)    ' restart_dir               = ', &
                                trim(restart_dir)

--- a/configuration/scripts/icepack_in
+++ b/configuration/scripts/icepack_in
@@ -10,6 +10,7 @@
     restart        = .false.
     restart_dir    = './restart/'
     dumpfreq       = 'y'
+    dump_last      = .false.
     diagfreq       = 24
     diag_file      = 'ice_diag'
     cpl_bgc        = .false.

--- a/configuration/scripts/options/set_nml.smoke
+++ b/configuration/scripts/options/set_nml.smoke
@@ -1,1 +1,2 @@
 #npt            = 24
+dump_last = .true.

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -112,6 +112,7 @@ column physics.
    "``dumpfreq``", "``y``", "write restart every ``dumpfreq_n`` years", "y"
    "", "``m``", "write restart every ``dumpfreq_n`` months", ""
    "", "``d``", "write restart every ``dumpfreq_n`` days", ""
+   "``dump_last``", "true/false", "write restart at end of run", "false"
    "", "", "*Model Output*", ""
    "``diagfreq``", "integer", "frequency of diagnostic output in ``dt``", "24"
    "", "*e.g.*, 10", "once every 10 time steps", ""

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -173,6 +173,8 @@ for a full, exact restart. The filename begins with the character string
 variable ``dumpfreq``. The namelist variable ``ice_ic`` contains the
 pointer to the filename from which the restart data is to be read and 
 the namelist option ``restart`` must be set to ``.true.`` to use the file.
+``dump_last`` namelist can also be set to true to trigger restarts automatically
+at then end of runs.
 
 .. _bgc-hist:
 

--- a/icepack.setup
+++ b/icepack.setup
@@ -679,7 +679,7 @@ EOF1
       endif
     endif
 
-    foreach name (${grid} ${setsx})
+    foreach name (${grid} ${test} ${setsx})
       set found = 0
       if (-e ${ICE_SCRIPTS}/options/set_nml.${name}) then
 
@@ -715,8 +715,14 @@ EOF2
         set found = 1
       endif
       if (${found} == 0) then
-        echo "${0}: ERROR, ${ICE_SCRIPTS}/options/set_[nml,env].${name} not found"
-        exit -1
+        if (${name} == ${test}) then
+          echo "${ICE_SCRIPTS}/options/set_[nml,env].${name} not found"
+          echo "`date`${0} ${ICE_SCRIPTS}/options/set_[nml,env].${name} not found" >> ${casedir}/README.case
+        else
+          echo "${0}: ERROR, ${ICE_SCRIPTS}/options/set_[nml,env].${name} not found"
+          echo "`date`${0}: ERROR, ${ICE_SCRIPTS}/options/set_[nml,env].${name} not found" >> ${casedir}/README.case
+          exit -1
+        endif
       endif
     end
 


### PR DESCRIPTION
Add dump_last namelist feature and turn it on for smoke tests by default.  Some bgc tests were not producing any restart files so no comparison or regression testing was working.  See issue #220. 

- Developer(s): tcraig

- Are the code changes bit for bit, different at roundoff level, or more substantial? bit-for-bit

- Is the documentation being updated with this PR? (Y/N) Y
If not, does the documentation need to be updated separately at a later time? (Y/N) 

- Other Relevant Details:

Tested on conrad with intel, pgi, cray, and gnu with all bgc tests as well as the quick_suite, bit-for-bit.  Verified restarts are created and regression testing works with smoke bgc tests.

