### PR TITLE
update warnings module and reduce pgi optimization

### DIFF
--- a/columnphysics/icepack_intfc.F90
+++ b/columnphysics/icepack_intfc.F90
@@ -84,7 +84,6 @@
       use icepack_therm_shared  , only: icepack_init_trcr
 
       use icepack_warnings, only: icepack_warnings_clear
-      use icepack_warnings, only: icepack_warnings_getall
       use icepack_warnings, only: icepack_warnings_print
       use icepack_warnings, only: icepack_warnings_flush
       use icepack_warnings, only: icepack_warnings_aborted

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -7,8 +7,7 @@
       module icepack_parameters
 
       use icepack_kinds
-      use icepack_warnings, only: warnstr, icepack_warnings_add
-      use icepack_warnings, only: icepack_warnings_setabort, icepack_warnings_aborted
+      use icepack_warnings, only: icepack_warnings_aborted
 
       implicit none
       private

--- a/columnphysics/icepack_warnings.F90
+++ b/columnphysics/icepack_warnings.F90
@@ -149,7 +149,7 @@ contains
              iWarning ! warning index
         character(len=*),parameter :: subname='(icepack_warnings_add)'
 
-!$OMP CRITICAL warnings_add
+!$OMP CRITICAL (omp_warnings_add)
         ! check if warnings array is not allocated
         if (.not. allocated(warnings)) then
 
@@ -194,7 +194,7 @@ contains
 
         ! increase warning number
         nWarnings = nWarnings + 1
-!$OMP END CRITICAL warnings_add
+!$OMP END CRITICAL (omp_warnings_add)
 
         ! add the new warning
         warnings(nWarnings) = trim(warning)

--- a/configuration/scripts/machines/Macros.conrad_pgi
+++ b/configuration/scripts/machines/Macros.conrad_pgi
@@ -14,7 +14,7 @@ FFLAGS_NOOPT:= -O0
 ifeq ($(ICE_BLDDEBUG), true)
   FFLAGS     += -O0 -g -Mbounds -Mchkptr
 else
-  FFLAGS     += -O2
+  FFLAGS     += -O -g
 endif
 
 ifeq ($(ICE_COMMDIR), mpi)

--- a/configuration/scripts/machines/Macros.gordon_pgi
+++ b/configuration/scripts/machines/Macros.gordon_pgi
@@ -14,7 +14,7 @@ FFLAGS_NOOPT:= -O0
 ifeq ($(ICE_BLDDEBUG), true)
   FFLAGS     += -O0 -g -Mbounds -Mchkptr
 else
-  FFLAGS     += -O2
+  FFLAGS     += -O -g
 endif
 
 ifeq ($(ICE_COMMDIR), mpi)


### PR DESCRIPTION
Update the warnings module to make it more thread-safe.  Reduce the pgi optimization consistent with recent CICE changes.

- Developer(s): tcraig

- Are the code changes bit for bit, different at roundoff level, or more substantial? bit-for-bit except for pgi.

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N

- Other Relevant Details:

Am getting intermittent recursive I/O runtime errors in the warnings package in CICE.  Not clear why that is but suspect it might be threads competing in the write phase of the warnings package.  This might or might not fix it, but it does improve the implementation in any case.

Reduced the pgi optimization.  O2 was giving reproducibility issues in CICE, that was reduced to O, so we're doing the same here.

Icepack test results are here, https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks, hash d4d68f11726.  CICE tests are being carried out now.
