### PR TITLE
Intent inout in shortwave_dEdd_set_snow

### DIFF
--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -3482,8 +3482,7 @@
          Tsfc   , & ! surface temperature 
          hs0        ! snow depth for transition to bare sea ice (m)
 
-!    real (kind=dbl_kind), intent(inout) :: &
-     real (kind=dbl_kind), intent(out) :: &
+     real (kind=dbl_kind), intent(inout) :: &
          fs     , & ! horizontal coverage of snow
          hs         ! snow depth
 


### PR DESCRIPTION
This fixes a bug where the variables fs and hs should be intent inout in shortwave_dEdd_set_snow. This change is bfb in icepack except for hobart_nag_restart_col_1x1_alt03. This is with ktherm=1 and the topo poinds. All of the hobart_intel tests passed and were bfb. I'm not sure why this one case is not bfb.

- Developer(s): D. Bailey

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- To verify that this PR passes the initial QC tests, lease include the link to test results
or paste in below the summary block from the bottom of the testing output.

- Does this PR create or have dependencies on CICE or any other models? 

- Is the documentation being updated with this PR? (Y/N)
If not, does the documentation need to be updated separately at a later time? (Y/N)

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
