### PR TITLE
remove initializations for multiple init calls

### DIFF
--- a/columnphysics/icepack_tracers.F90
+++ b/columnphysics/icepack_tracers.F90
@@ -519,28 +519,6 @@
         if (present(nt_zbgc_frac_in) ) nt_zbgc_frac  = nt_zbgc_frac_in
         if (present(nt_bgc_S_in)     ) nt_bgc_S      = nt_bgc_S_in
 
-        nt_bgc_N(:)    = 0
-        nt_bgc_C(:)    = 0
-        nt_bgc_chl(:)  = 0
-        nlt_bgc_N(:)   = 0
-        nlt_bgc_C(:)   = 0
-        nlt_bgc_chl(:) = 0
-        nt_bgc_DOC(:)  = 0
-        nlt_bgc_DOC(:) = 0
-        nt_bgc_DIC(:)  = 0
-        nlt_bgc_DIC(:) = 0
-        nt_bgc_DON(:)  = 0
-        nlt_bgc_DON(:) = 0
-        nt_bgc_Fed(:)  = 0
-        nt_bgc_Fep(:)  = 0
-        nlt_bgc_Fed(:) = 0
-        nlt_bgc_Fep(:) = 0
-        nt_zaero(:)    = 0
-        nlt_zaero(:)   = 0
-        nlt_zaero_sw(:)= 0
-        bio_index(:)   = 0
-        bio_index_o(:) = 0
-
         if (present(nbtrcr_in)) then
            nbtrcr = nbtrcr_in
            do k = 1, nbtrcr_in


### PR DESCRIPTION
Calls to init_tracer_indices without a complete argument list subsequent to the first call would reset the non-present indices to zero.

- Developer(s):  E. Hunke

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial?  BFB

- To verify that this PR passes the initial QC tests, lease include the link to test results
or paste in below the summary block from the bottom of the testing output.

- Does this PR create or have dependencies on CICE or any other models?  No

- Is the documentation being updated with this PR? (Y/N)  No
If not, does the documentation need to be updated separately at a later time? (Y/N)  No

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
