### PR TITLE
fixing typo in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,7 +6,7 @@
 
 - Are the code changes bit for bit, different at roundoff level, or more substantial?
 
-- To verify that this PR passes the initial QC tests, lease include the link to test results
+- To verify that this PR passes the initial QC tests, please include the link to test results
 or paste in below the summary block from the bottom of the testing output.
 
 - Does this PR create or have dependencies on CICE or any other models? 


### PR DESCRIPTION
Fixed the bolded typo in the PR template. 

- Developer(s): Alice

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? b4b

- To verify that this PR passes the initial QC tests, **lease** include the link to test results
or paste in below the summary block from the bottom of the testing output.

- Does this PR create or have dependencies on CICE or any other models? 

- Is the documentation being updated with this PR? (Y/N)
If not, does the documentation need to be updated separately at a later time? (Y/N)

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
