### PR TITLE
fix readthedocs url

### DIFF
--- a/doc/source/developer_guide/dg_documentation.rst
+++ b/doc/source/developer_guide/dg_documentation.rst
@@ -7,7 +7,7 @@ Documentation System
 
 With Icepack development, corresponding updates or modification to the Icepack
 documentation are required. Whenever you modify the model you should update
-documentation. Icepack uses `readthedocs.org <readthedocs.org>`_ to create 
+documentation. Icepack uses `readthedocs.org <https://readthedocs.org>`_ to create 
 online HTML and PDF documentation.
 
 FAQs
@@ -17,8 +17,8 @@ FAQs
 
    The CICE and Icepack documentation is written using reStructuredText (RST) markup language. 
    ReStructuredText is a markup language, like HTML, markdown, or LaTeX. 
-   `readthedocs.org <readthedocs.org>`_ is a tool for publishing RST documents in other formats 
-   such as HTML and PDF. Additional information about using RST and `readthedocs.org <readthedocs.org>`_ 
+   `readthedocs.org <https://readthedocs.org>`_ is a tool for publishing RST documents in other formats 
+   such as HTML and PDF. Additional information about using RST and `readthedocs.org <https://readthedocs.org>`_ 
    are found in the sections below.
 
 2) What is expected of *me* when changing the documentation?
@@ -59,12 +59,12 @@ Steps for Modifying Documentation
 Setting up readthedocs.org
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The CICE-Consortium recommends that developers use `readthedocs.org <readthedocs.org>`_ to generate and test
+The CICE-Consortium recommends that developers use `readthedocs.org <https://readthedocs.org>`_ to generate and test
 their contributions to the Icepack documentation. This tool does not require external libraries to be built
 on each developer's personal computer and is free and easy to use. You can follow the steps below and also
-reference the `Getting Started <https://docs.readthedocs.io/en/latest/getting_started.html>`_ guide available from `readthedocs.org <readthedocs.org>`_. 
+reference the `Getting Started <https://docs.readthedocs.io/en/latest/getting_started.html>`_ guide available from `readthedocs.org <https://readthedocs.org>`_. 
 
-1. Sign up for a free account at `readthedocs.org <readthedocs.org>`_
+1. Sign up for a free account at `readthedocs.org <https://readthedocs.org>`_
 
    Select a username and password. These do not have to match your GitHub username and password, but having
    the same username can be simpler if the user choses to do this. Below, 
@@ -195,7 +195,7 @@ converted with Pandoc.
 Using Sphinx
 ~~~~~~~~~~~~
 
-We recommend that you use `readthedocs.org <readthedocs.org>`_ to test documentation
+We recommend that you use `readthedocs.org <https://readthedocs.org>`_ to test documentation
 (see :ref:`moddocs`). However, it is also possible to use Sphinx to build and test documentation. 
 If you choose to follow this workflow, below are some tips for using Sphinx. 
 

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -29,25 +29,25 @@ The directory structure of Icepack is as follows.  All columnphysics filename ha
 of icepack\_ and all driver files are prefixed with icedrv\_*.
 
 **LICENSE.pdf**
-  license and policy for using and sharing the code
+  license for using and sharing the code
 
 **DistributionPolicy.pdf**
-  license and policy for using and sharing the code
+  policy for using and sharing the code
 
 **README.md**
   basic information and pointers
 
 **columnphysics/**
-   directory for columnphysics source code, see :ref:`dev_colphys`
+  columnphysics source code, see :ref:`dev_colphys`
 
 **configuration/scripts/**
-   directory of support scripts, see :ref:`dev_scripts`
+  support scripts, see :ref:`dev_scripts`
 
 **configuration/driver/**
-   directory of icepack driver code, see :ref:`dev_driver`
+  icepack driver code, see :ref:`dev_driver`
 
 **doc/**
-    documentation
+  documentation
 
 **icepack.setup**
   main icepack script for creating cases


### PR DESCRIPTION
Testing the process for testing the documentation using readthedocs revealed some URL errors

- Developer(s):   E. Hunke

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial?  BFB

- To verify that this PR passes the initial QC tests, please include the link to test results
or paste in below the summary block from the bottom of the testing output.

- Does this PR create or have dependencies on CICE or any other models? 

- Is the documentation being updated with this PR? (Y/N)  yes
If not, does the documentation need to be updated separately at a later time? (Y/N)  

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:

https://icepack-eclare.readthedocs.io/en/doc1/index.html

This needs to be fixed in the CICE docs too.

The instructions are very clear up to the point where you want to look at documentation for a branch rather than master.   I managed to click around until I found it, something like this:
Click on Versions, find your branch in the "Inactive" list, click 'Edit' then check the 'Active' box and save.  Then click on 'Builds' and the branch name.   Is there an easier way?  If not, maybe we should add these instructions to the docs (both Icepack and CICE).

I might add more commits here -- don't merge yet please.