### PR TITLE
update cheyenne modules for machine upgrade

### DIFF
--- a/configuration/scripts/machines/Macros.cheyenne_intel
+++ b/configuration/scripts/machines/Macros.cheyenne_intel
@@ -33,24 +33,25 @@ NETCDF_PATH := $(NETCDF)
 PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
 
 #PNETCDF_PATH := $(PNETCDF)
-PNETCDF_PATH := /glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/lib
+#PNETCDF_PATH := /glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/lib
 
 INCLDIR := $(INCLDIR)
 
 LIB_NETCDF := $(NETCDF_PATH)/lib
-LIB_PNETCDF := $(PNETCDF_PATH)/lib
+#LIB_PNETCDF := $(PNETCDF_PATH)/lib
 LIB_MPI := $(IMPILIBDIR)
 
-SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff -L$(LIB_PNETCDF) -lpnetcdf -lgptl
+#SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff -L$(LIB_PNETCDF) -lpnetcdf -lgptl
+SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
 
 SCC:= icc 
 
 SFC:= ifort 
 
 ifeq ($(compile_threaded), true) 
-   LDFLAGS += -openmp 
-   CFLAGS += -openmp 
-   FFLAGS += -openmp 
+   LDFLAGS += -qopenmp 
+   CFLAGS += -qopenmp 
+   FFLAGS += -qopenmp 
 endif
 
 ifeq ($(DITTO), yes)

--- a/configuration/scripts/machines/env.cheyenne_intel
+++ b/configuration/scripts/machines/env.cheyenne_intel
@@ -3,11 +3,11 @@
 source /glade/u/apps/ch/opt/lmod/7.2.1/lmod/7.2.1/init/csh
 
 module purge
-module load ncarenv/1.1
+module load ncarenv/1.2
 module load intel/17.0.1
-module load mpt/2.15f
+module load mpt/2.19
 module load ncarcompilers/0.4.1
-module load pio/2.2.0
+module load netcdf-mpi/4.6.1
 
 setenv ICE_MACHINE_ENVNAME cheyenne
 setenv ICE_MACHINE_COMPILER intel


### PR DESCRIPTION
Update cheyenne, required with machine upgrade early March, 2019

- Developer(s): tcraig

- Are the code changes bit for bit, different at roundoff level, or more substantial?  bit-for-bit, see a838da5 at https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks

- Does this PR create or have dependencies on CICE or any other models?  No

- Is the documentation being updated with this PR? (Y/N) No
If not, does the documentation need to be updated separately at a later time? (Y/N) No

- Other Relevant Details:

Full test suite is bit-for-bit with last weekend test. Old modules no longer supported with machine upgrade in early March, 2019. These changes should be usable in older versions of Icepack as well.