### PR TITLE
Move makdep compilation to Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,17 @@ language: cpp
 
 sudo: false
 
-compiler: clang
-
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
     packages:
       - tcsh
       - pkg-config
       - netcdf-bin
       - libnetcdf-dev
       - gfortran
-      - clang-5.0
+      - gcc
       - wget
       #- lftp
 

--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -114,7 +114,7 @@ ifndef $(CFLAGS_HOST)
   CFLAGS_HOST :=
 endif
 
-makdep: $(ICE_CASEDIR)/makdep.c
+$(DEPGEN): $(ICE_CASEDIR)/makdep.c
 	$(SCC) -o $@ $(CFLAGS_HOST) $<
 
 #-------------------------------------------------------------------------------

--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -106,6 +106,18 @@ db_flags:
 	@echo "* .F90.o  := $(FC) -c $(FFLAGS) $(FREEFLAGS) $(INCS) $(INCLDIR)"
 
 #-------------------------------------------------------------------------------
+# build rule for makdep: MACFILE, cmd-line, or env vars must provide
+# the needed macros
+#-------------------------------------------------------------------------------
+
+ifndef $(CFLAGS_HOST)
+  CFLAGS_HOST :=
+endif
+
+makdep: $(ICE_CASEDIR)/makdep.c
+	$(SCC) -o $@ $(CFLAGS_HOST) $<
+
+#-------------------------------------------------------------------------------
 # build rules: MACFILE, cmd-line, or env vars must provide the needed macros
 #-------------------------------------------------------------------------------
 

--- a/configuration/scripts/icepack.build
+++ b/configuration/scripts/icepack.build
@@ -64,7 +64,8 @@ cat ${ICE_OBJDIR}/Filepath
 echo " "
 
 echo "building makdep"
-cc -o makdep ${ICE_CASEDIR}/makdep.c     || exit 2
+${ICE_MACHINE_MAKE} \
+        -f  ${ICE_CASEDIR}/Makefile MACFILE=${ICE_CASEDIR}/Macros.${ICE_MACHCOMP} makdep || exit 2
 
 echo "building icepack > ${ICE_OBJDIR}/${ICE_BLDLOG_FILE}"
 if ( ${ICE_TEST} != ${ICE_SPVAL} ) then

--- a/configuration/scripts/machines/Macros.badger_intel
+++ b/configuration/scripts/machines/Macros.badger_intel
@@ -18,16 +18,11 @@ else
   FFLAGS     += -O1
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-else
-  FC         := ifort
-endif
-
-MPICC:= mpicc
-
-MPIFC:= mpif90
-LD:= $(MPIFC)
+SCC := icc
+SFC := ifort
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # set in Macros file
 NETCDF_PATH := /usr/projects/climate/SHARED_CLIMATE/software/conejo/netcdf/3.6.3/intel-13.0.1
@@ -50,9 +45,6 @@ else
   SLIBS   := 
 endif
 
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -qopenmp

--- a/configuration/scripts/machines/Macros.cheyenne_intel
+++ b/configuration/scripts/machines/Macros.cheyenne_intel
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-else
-  FC         := ifort
-endif
-
-MPICC:= mpicc
-
-MPIFC:= mpif90
-LD:= $(MPIFC)
+SCC := icc
+SFC := ifort
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 NETCDF_PATH := $(NETCDF)
 
@@ -43,10 +38,6 @@ LIB_MPI := $(IMPILIBDIR)
 
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff -L$(LIB_PNETCDF) -lpnetcdf -lgptl
 SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(compile_threaded), true) 
    LDFLAGS += -qopenmp 

--- a/configuration/scripts/machines/Macros.conrad_cray
+++ b/configuration/scripts/machines/Macros.conrad_cray
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= cc
-
-SFC:= ftn
 
 ifeq ($(ICE_THREADED), false) 
    LDFLAGS += -hnoomp

--- a/configuration/scripts/machines/Macros.conrad_gnu
+++ b/configuration/scripts/machines/Macros.conrad_gnu
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -fopenmp

--- a/configuration/scripts/machines/Macros.conrad_intel
+++ b/configuration/scripts/machines/Macros.conrad_intel
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -openmp

--- a/configuration/scripts/machines/Macros.conrad_pgi
+++ b/configuration/scripts/machines/Macros.conrad_pgi
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O -g
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= cc
-
-SFC:= ftn
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -mp

--- a/configuration/scripts/machines/Macros.cori_intel
+++ b/configuration/scripts/machines/Macros.cori_intel
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -openmp

--- a/configuration/scripts/machines/Macros.gaffney_gnu
+++ b/configuration/scripts/machines/Macros.gaffney_gnu
@@ -1,5 +1,5 @@
 #==============================================================================
-# Macros file for NAVYDSRC gaffney, intel compiler
+# Macros file for NAVYDSRC gaffney, gnu compiler
 #==============================================================================
 
 CPP        := ftn -E
@@ -17,17 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-  LDFLAGS += -lmpi
-else
-  FC         := gfortran
-endif
-
-MPICC:= mpicc
-MPIFC:= mpif90
-#LD:= $(MPIFC)
-LD:= gfortran
+SCC := gcc
+SFC := gfortran
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -44,10 +38,6 @@ INCLDIR += -I$(NETCDF_PATH)/include
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -fopenmp

--- a/configuration/scripts/machines/Macros.gaffney_intel
+++ b/configuration/scripts/machines/Macros.gaffney_intel
@@ -18,17 +18,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ifort
-  LDFLAGS += -lmpi
-else
-  FC         := ifort
-endif
-
-MPICC:= icc
-
-MPIFC:= ifort
-LD:= $(MPIFC)
+SCC := icc
+SFC := ifort
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -45,10 +39,6 @@ LIB_NETCDF := $(NETCDF_PATH)/lib
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -qopenmp

--- a/configuration/scripts/machines/Macros.gaffney_pgi
+++ b/configuration/scripts/machines/Macros.gaffney_pgi
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O -g
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-else
-  FC         := pgf90
-endif
-
-MPICC:= pgcc
-
-MPIFC:= pgf90
-LD:= $(MPIFC)
+SCC := pgcc
+SFC := pgf90
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= pgcc
-
-SFC:= pgf90
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -mp

--- a/configuration/scripts/machines/Macros.gordon_cray
+++ b/configuration/scripts/machines/Macros.gordon_cray
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= cc
-
-SFC:= ftn
 
 ifeq ($(ICE_THREADED), false) 
    LDFLAGS += -hnoomp

--- a/configuration/scripts/machines/Macros.gordon_gnu
+++ b/configuration/scripts/machines/Macros.gordon_gnu
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -fopenmp

--- a/configuration/scripts/machines/Macros.gordon_intel
+++ b/configuration/scripts/machines/Macros.gordon_intel
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -openmp

--- a/configuration/scripts/machines/Macros.gordon_pgi
+++ b/configuration/scripts/machines/Macros.gordon_pgi
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O -g
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= cc
-
-SFC:= ftn
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -mp

--- a/configuration/scripts/machines/Macros.hobart_intel
+++ b/configuration/scripts/machines/Macros.hobart_intel
@@ -18,11 +18,9 @@ else
   FFLAGS     += -O2 -debug minimal
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-  LD         := mpif90
-else
-  FC         := ifort
-  LD         := ifort
-endif
+SCC := icc
+SFC := ifort
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 

--- a/configuration/scripts/machines/Macros.hobart_nag
+++ b/configuration/scripts/machines/Macros.hobart_nag
@@ -1,5 +1,5 @@
 #==============================================================================
-# Makefile macros for NCAR cheyenne, intel compiler
+# Makefile macros for NCAR cheyenne, nag compiler
 #==============================================================================
 
 CPP        := /usr/bin/cpp
@@ -19,13 +19,11 @@ else
   FFLAGS   += -O2 -ieee=full
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-  LD         := mpif90
-else
-  FC         := nagfor
-  LD         := nagfor
-endif
+SCC := nagcc
+SFC := nagfor
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 SLIBS   := -L$(COMPILER_PATH)/lib/NAG_Fortran
 

--- a/configuration/scripts/machines/Macros.koehr_gnu
+++ b/configuration/scripts/machines/Macros.koehr_gnu
@@ -17,17 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-  LDFLAGS += -lmpi
-else
-  FC         := gfortran
-endif
-
-MPICC:= mpicc
-MPIFC:= mpif90
-#LD:= $(MPIFC)
-LD:= gfortran
+SCC := gcc
+SFC := gfortran
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -44,10 +38,6 @@ INCLDIR += -I$(NETCDF_PATH)/include
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -fopenmp

--- a/configuration/scripts/machines/Macros.koehr_intel
+++ b/configuration/scripts/machines/Macros.koehr_intel
@@ -18,17 +18,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ifort
-  LDFLAGS += -lmpi
-else
-  FC         := ifort
-endif
-
-MPICC:= icc
-
-MPIFC:= ifort
-LD:= $(MPIFC)
+SCC := icc
+SFC := ifort
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -45,10 +39,6 @@ LIB_NETCDF := $(NETCDF_PATH)/lib
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -qopenmp

--- a/configuration/scripts/machines/Macros.koehr_pgi
+++ b/configuration/scripts/machines/Macros.koehr_pgi
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O -g
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-else
-  FC         := pgf90
-endif
-
-MPICC:= pgcc
-
-MPIFC:= pgf90
-LD:= $(MPIFC)
+SCC := pgcc
+SFC := pgf90
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= pgcc
-
-SFC:= pgf90
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -mp

--- a/configuration/scripts/machines/Macros.loft_gnu
+++ b/configuration/scripts/machines/Macros.loft_gnu
@@ -27,12 +27,11 @@ else
   FFLAGS     += -O2
 endif
 
- 	FC         := gfortran
-
-MPICC:= 
-
-MPIFC:= 
-LD:= $(FC)
+SCC := gcc
+SFC := gfortran
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 ifeq ($(ICE_IOTYPE), netcdf)
   NETCDF_PATH := /usr/projects/climate/SHARED_CLIMATE/software/conejo/netcdf/3.6.3/intel-13.0.1
@@ -45,8 +44,6 @@ else
 endif
 
 LIB_MPI := 
-SCC:= 
-SFC:= 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -openmp

--- a/configuration/scripts/machines/Macros.onyx_cray
+++ b/configuration/scripts/machines/Macros.onyx_cray
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= cc
-
-SFC:= ftn
 
 ifeq ($(ICE_THREADED), false) 
    LDFLAGS += -hnoomp

--- a/configuration/scripts/machines/Macros.onyx_gnu
+++ b/configuration/scripts/machines/Macros.onyx_gnu
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -fopenmp

--- a/configuration/scripts/machines/Macros.onyx_intel
+++ b/configuration/scripts/machines/Macros.onyx_intel
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := ftn
-else
-  FC         := ftn
-endif
-
-MPICC:= cc
-
-MPIFC:= ftn
-LD:= $(MPIFC)
+SCC := cc
+SFC := ftn
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ INCLDIR := $(INCLDIR)
 #LIB_PNETCDF := $(PNETCDF_PATH)/lib
 #LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -openmp

--- a/configuration/scripts/machines/Macros.testmachine_intel
+++ b/configuration/scripts/machines/Macros.testmachine_intel
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-else
-  FC         := ifort
-endif
-
-MPICC:= mpicc
-
-MPIFC:= mpif90
-LD:= $(MPIFC)
+SCC := icc
+SFC := ifort
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 NETCDF_PATH := $(NETCDF)
 
@@ -42,10 +37,6 @@ LIB_PNETCDF := $(PNETCDF_PATH)/lib
 LIB_MPI := $(IMPILIBDIR)
 
 SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff -L$(LIB_PNETCDF) -lpnetcdf -lgptl
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(compile_threaded), true) 
    LDFLAGS += -openmp 

--- a/configuration/scripts/machines/Macros.thunder_intel
+++ b/configuration/scripts/machines/Macros.thunder_intel
@@ -17,16 +17,11 @@ else
   FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COMMDIR), mpi)
-  FC         := mpif90
-else
-  FC         := ifort
-endif
-
-MPICC:= mpicc
-
-MPIFC:= mpif90
-LD:= $(MPIFC)
+SCC := icc
+SFC := ifort
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
 
 # defined by module
 #NETCDF_PATH := $(NETCDF)
@@ -43,10 +38,6 @@ LIB_NETCDF := $(NETCDF_PATH)/lib
 LIB_PNETCDF := $(PNETCDF_PATH)/lib
 LIB_MPI := $(IMPILIBDIR)
 SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-
-SCC:= icc 
-
-SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -qopenmp

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -16,10 +16,10 @@ else
     FFLAGS     += -O2
 endif
 
-FC := gfortran
-CC := gcc
-SCC := $(CC)
-SFC := $(FC)
+SCC := gcc
+SFC := gfortran
+CC := $(SCC)
+FC := $(SFC)
 LD := $(FC)
 
 NETCDF_PATH := $(NETCDF)

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -1,8 +1,8 @@
 #==============================================================================
-# Makefile macros for Travis-CI - gfortran and llvm (clang) compilers
+# Makefile macros for Travis-CI - gnu compiler
 #==============================================================================
 
-CPP        := clang-cpp
+CPP        := /usr/bin/cpp
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
 CFLAGS     := -c -O2 -fp-model precise   -xHost
 
@@ -17,11 +17,10 @@ else
 endif
 
 FC := gfortran
-
-MPICC:= 
-
-MPIFC:= 
-LD:= $(FC)
+CC := gcc
+SCC := $(CC)
+SFC := $(FC)
+LD := $(FC)
 
 NETCDF_PATH := $(NETCDF)
 
@@ -36,8 +35,6 @@ else
 endif
 
 LIB_MPI := 
-SCC:= 
-SFC:= 
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -openmp

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -16,6 +16,8 @@ The icepack scripts are written to allow quick setup of cases and tests.  Once a
 generated, users can manually modify the namelist and other files to custom configure
 the case.  Several settings are available via scripts as well.
 
+.. _overview:
+
 Overview
 ~~~~~~~~
 
@@ -236,7 +238,7 @@ There are other scripts that come with icepack.  These include
 Porting
 -------
 
-To port, an **env.[machine]_[environment]** and **Macros.[machine]_[environment}** file have to be added to the
+To port, an **env.[machine]_[environment]** and **Macros.[machine]_[environment]** file have to be added to the
 **configuration/scripts/machines/** directory and the 
 **configuration/scripts/icepack.batch.csh** file needs to be modified.
 In general, the machine is specified in ``icepack.setup`` with ``--mach``
@@ -263,6 +265,16 @@ file until the case can build and run.  Then copy the files from the case
 directory back to **configuration/scripts/machines/** and update 
 the **configuration/scripts/icepack.batch.csh** file, retest, 
 and then add and commit the updated machine files to the repository.
+
+.. _cross_compiling:
+
+Cross-compiling
+~~~~~~~~~~~~~~~~~~~~~~~~
+It can happen that the model must be built on a platform and run on another, for example when the run environment is only available in a batch queue. The program **makdep** (see :ref:`overview`), however, is both compiled and run as part of the build process.
+
+In order to support this, the Makefile uses a variable ``CFLAGS_HOST`` that can hold compiler flags specfic to the build machine for the compilation of makdep. If this feature is needed, add the variable ``CFLAGS_HOST`` to the **Macros.[machine]_[environment]** file. For example : ::
+
+  CFLAGS_HOST = -xHost
 
 .. _account:
 


### PR DESCRIPTION
* makdep compiled from a makdep rule in the Makefile
* Add CFLAG_HOST macro
* makdep is only compiled if needed
* This addresses CICE-Consortium/CICE#306

- Developer(s): Philippe Blain

- Please suggest code Pull Request reviewers in the column at right. @apcraig 

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- To verify that this PR passes the initial QC tests, please include the link to test results
or paste in below the summary block from the bottom of the testing output.
No tests, did not modify source code.

- Does this PR create or have dependencies on CICE or any other models? No

- Is the documentation being updated with this PR? (Y/N) Yes
[https://icepack-phil-blain.readthedocs.io/en/build-system-robustness/user_guide/ug_running.html#cross-compiling](https://icepack-phil-blain.readthedocs.io/en/build-system-robustness/user_guide/ug_running.html#cross-compiling)
If not, does the documentation need to be updated separately at a later time? (Y/N) No

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
