### PR TITLE
Add code coverge capability

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+# do not comment with code coverage metrics in github pull requests
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - gfortran
       - gcc
       - wget
+      - curl
       #- lftp
 
 install:
@@ -24,7 +25,6 @@ install:
   # Mirror entire data folder
   #- "lftp ftp://anonymous:travis@travis-ci.org@ftp.cgd.ucar.edu 
   #-e 'mirror /archive/Model-Data/CICE/ ~/ICEPACK_INPUTDATA; quit'"
-
 
 script:
   - "./icepack.setup --suite travis_suite --testid travisCItest 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/CICE-Consortium/Icepack.svg?branch=master)](https://travis-ci.org/CICE-Consortium/Icepack)
 [![Documentation Status](https://readthedocs.org/projects/cice-consortium-icepack/badge/?version=master)](http://cice-consortium-icepack.readthedocs.io/en/master/?badge=master)
+[![codecov.io](http://codecov.io/github/CICE-Consortium/Icepack/coverage.svg?branch=master)](http://codecov.io/github/CICE-Consortium/Icepack?branch=master)
 
 ## Overview
 This repository contains files for Icepack, the column physics of the sea ice model CICE. Icepack is maintained by the CICE Consortium.  For testing purposes and guidance for including Icepack in other sea ice host models, this repository also includes a driver and basic test suite.   

--- a/configuration/scripts/icepack.settings
+++ b/configuration/scripts/icepack.settings
@@ -75,5 +75,6 @@ setenv TRFED     0         # number of dissolved iron tracers
 
 ### Specialty code
 setenv ICE_BLDDEBUG  false  # build debug flags
+setenv ICE_CODECOV  false   # code coverage flag
 
 

--- a/configuration/scripts/machines/Macros.conrad_gnu
+++ b/configuration/scripts/machines/Macros.conrad_gnu
@@ -4,7 +4,7 @@
 
 CPP        := ftn -E
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -ffloat-store -march=native
+CFLAGS     := -c -ffloat-store -march=native
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -ffloat-store -fconvert=swap -fbacktrace -march=native -ffree-line
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -Wuninitialized -fbounds-check -ffpe-trap=invalid,zero,overflow,underflow
-else
-  FFLAGS     += -O2
+   FFLAGS  += -O0 -g -Wuninitialized -fbounds-check -ffpe-trap=invalid,zero,overflow,underflow
+   CFLAGS  += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O0 -g -fprofile-arcs -ftest-coverage
+   CFLAGS  += -O0 -g -coverage
+   LDFLAGS += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O2
+   CFLAGS  += -O2
+endif
 endif
 
 SCC := cc

--- a/configuration/scripts/machines/Macros.gaffney_gnu
+++ b/configuration/scripts/machines/Macros.gaffney_gnu
@@ -4,7 +4,7 @@
 
 CPP        := ftn -E
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2
+CFLAGS     := -c
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-else
-  FFLAGS     += -O2
+   FFLAGS  += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+   CFLAGS  += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O0 -g -fprofile-arcs -ftest-coverage
+   CFLAGS  += -O0 -g -coverage
+   LDFLAGS += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O2
+   CFLAGS  += -O2
+endif
 endif
 
 SCC := gcc

--- a/configuration/scripts/machines/Macros.gordon_gnu
+++ b/configuration/scripts/machines/Macros.gordon_gnu
@@ -4,7 +4,7 @@
 
 CPP        := ftn -E
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -ffloat-store -march=native
+CFLAGS     := -c -ffloat-store -march=native
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -ffloat-store -fconvert=swap -fbacktrace -march=native -ffree-line
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -Wuninitialized -fbounds-check -ffpe-trap=invalid,zero,overflow,underflow
-else
-  FFLAGS     += -O2
+   FFLAGS  += -O0 -g -Wuninitialized -fbounds-check -ffpe-trap=invalid,zero,overflow,underflow
+   CFLAGS  += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O0 -g -fprofile-arcs -ftest-coverage
+   CFLAGS  += -O0 -g -coverage
+   LDFLAGS += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O2
+   CFLAGS  += -O2
+endif
 endif
 
 SCC := cc

--- a/configuration/scripts/machines/Macros.high_Sierra_gnu
+++ b/configuration/scripts/machines/Macros.high_Sierra_gnu
@@ -1,5 +1,5 @@
 #==============================================================================
-# Makefile macros for Travis-CI - GCC and openmpi compilers
+# Makefile macros for high_Sierra - GCC and openmpi compilers
 #==============================================================================
 
 CPP        := cpp

--- a/configuration/scripts/machines/Macros.koehr_gnu
+++ b/configuration/scripts/machines/Macros.koehr_gnu
@@ -1,10 +1,10 @@
 #==============================================================================
-# Macros file for NAVYDSRC koehr, intel compiler
+# Macros file for NAVYDSRC koehr, gnu compiler
 #==============================================================================
 
 CPP        := ftn -E
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2
+CFLAGS     := -c
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-else
-  FFLAGS     += -O2
+   FFLAGS  += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+   CFLAGS  += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O0 -g -fprofile-arcs -ftest-coverage
+   CFLAGS  += -O0 -g -coverage
+   LDFLAGS += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O2
+   CFLAGS  += -O2
+endif
 endif
 
 SCC := gcc

--- a/configuration/scripts/machines/Macros.onyx_gnu
+++ b/configuration/scripts/machines/Macros.onyx_gnu
@@ -4,7 +4,7 @@
 
 CPP        := ftn -E
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -ffloat-store -march=native
+CFLAGS     := -c -ffloat-store -march=native
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -ffloat-store -fconvert=swap -fbacktrace -march=native -ffree-line
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -Wuninitialized -fbounds-check -ffpe-trap=invalid,zero,overflow,underflow
-else
-  FFLAGS     += -O2
+   FFLAGS  += -O0 -g -Wuninitialized -fbounds-check -ffpe-trap=invalid,zero,overflow,underflow
+   CFLAGS  += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O0 -g -fprofile-arcs -ftest-coverage
+   CFLAGS  += -O0 -g -coverage
+   LDFLAGS += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O2
+   CFLAGS  += -O2
+endif
 endif
 
 SCC := cc

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -4,16 +4,28 @@
 
 CPP        := /usr/bin/cpp
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -fp-model precise   -xHost
+CFLAGS     := -c -fp-model precise   -xHost
 
 FIXEDFLAGS := -132
-FFLAGS     :=  -O2 -ffree-line-length-none -fconvert=big-endian -finit-real=nan
+FFLAGS     :=  -ffree-line-length-none -fconvert=big-endian -finit-real=nan
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-    FFLAGS     += -O0 -g -Wextra -fbacktrace -fbounds-check -ffpe-trap=zero,overflow
-else
-    FFLAGS     += -O2
+   FFLAGS  += -O0 -g -Wextra -fbacktrace -fbounds-check -ffpe-trap=zero,overflow
+   CFLAGS  += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O0 -g -fprofile-arcs -ftest-coverage
+   CFLAGS  += -O0 -g -coverage
+   LDFLAGS += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
+   FFLAGS  += -O2
+   CFLAGS  += -O2
+endif
 endif
 
 SCC := gcc
@@ -29,7 +41,7 @@ ifeq ($(ICE_IOTYPE), netcdf)
     INCLDIR := $(INCLDIR) -I$(NETCDF_PATH)/include
     LIB_NETCDF := $(NETCDF_PATH)/lib
     LIB_PNETCDF := 
-    SLIBS   := -L$(LIB_NETCDF) -lnetcdf 
+    SLIBS   := -L$(LIB_NETCDF) -lnetcdf
 else
     SLIBS   := 
 endif

--- a/configuration/scripts/tests/report_results.csh
+++ b/configuration/scripts/tests/report_results.csh
@@ -36,6 +36,7 @@ set hash = `grep "#hash = " results.log | cut -c 9-`
 set shhash   = `grep "#hshs = " results.log | cut -c 9-`
 set hashuser = `grep "#hshu = " results.log | cut -c 9-`
 set hashdate = `grep "#hshd = " results.log | cut -c 9-`
+set testsuites = `grep "#suit = " results.log | cut -c 9-`
 set cdat = `grep "#date = " results.log | cut -c 9-`
 set ctim = `grep "#time = " results.log | cut -c 9-`
 set user = `grep "#user = " results.log | cut -c 9-`
@@ -53,6 +54,7 @@ set compilers = `grep -v "#" results.log | grep ${mach}_ | cut -d "_" -f 2 | sor
 #echo "debug ${shhash}"
 #echo "debug ${hashuser}"
 #echo "debug ${hashdate}"
+#echo "debug ${testsuites}"
 #echo "debug ${cdat}"
 #echo "debug ${ctim}"
 #echo "debug ${user}"

--- a/doc/source/developer_guide/dg_scripts.rst
+++ b/doc/source/developer_guide/dg_scripts.rst
@@ -93,17 +93,28 @@ Test scripts
 -------------
 
 Under **configuration/scripts/tests** are several files including the scripts to 
-setup the smoke and restart tests (**test_smoke.script**, **test_restart.script*).
-A baseline test script (**baseline.script**) is also there to setup the regression
+setup the various tests, such as smoke and restart tests (**test_smoke.script**, 
+**test_restart.script**).
+and the files that describe which options files are needed for each test 
+(ie. **test_smoke.files**, **test_restart.files**).
+A baseline test script (**baseline.script**) is also there to setup the general regression
 and comparison testing.  That directory also contains the preset test suites 
 (ie. **base_suite.ts**) and a file that supports post-processing on the model
-output (**timeseries.csh**).  
+output (**timeseries.csh**).  There is also a script **report_results.csh** that 
+pushes results from test suites back to the CICE-Consortium test results wiki page.
 
-There is a subdirectory, **configuration/scripts/tests/CTest**, that supports the
-CTest scripts.  These scripts allow test reporting to CDash.
+To add a new test (for example newtest), several files may be needed,
 
-To add a new test, a file associated with that test will need to be added to the
-**configuration/scripts/tests** directory similar to **test_smoke.script** 
-and **test_restart.script**.  In addition, some new options files in 
-**configuration/scripts/options** may need to be added similar to **test_nml.restart1**,
-**test_nml.restart2**, and **set_nml.restart**.  
+- **configuration/scripts/tests/test_newtest.script** defines how to run the test.  This chunk
+  of script will be incorporated into the case test script
+- **configuration/scripts/tests/test_newtest.files** list the set of options files found in
+  **configuration/scripts/options/** needed to
+  run this test.  Those files will be copied into the test directory when the test is invoked
+  so they are available for the **test_newtest.script** to use.
+- some new files may be needed in **configuration/scripts/options/**.  These could be 
+  relatively generic **set_nml** or **set_env** files, or they could be test specific files 
+  typically carrying a prefix of **test_nml**.
+
+Generating a new test, particularly the **test_newtest.script** usually takes some iteration 
+before it's working properly.
+

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -304,6 +304,9 @@ following options are valid for suites,
 ``--report``
   This is only used by ``--suite`` and when set, invokes a script that sends the test results to the results page when all tests are complete.  Please see :ref:`testreporting` for more information.
 
+``--codecov``
+  When invoked, code coverage diagnostics are run.  This includes modifications to the build, including reduced optimization.  The results will be uploaded to the **codecov.io** website automaticaly via the **report_codecov.csh** script.  Please see :ref:`codecoverage` for more information.
+
 Please see :ref:`case_options` and :ref:`indtests` for more details about how these options are used.
 
 
@@ -542,3 +545,21 @@ This plotting script can be used to plot the following variables:
   - congelation (m)
   - snow-ice (m)
   - initial energy change (:math:`W/m^2`)
+
+.. _codecoverage:
+
+Code Coverage Testing
+---------------
+
+The ``--codecov`` feature in **icepack.setup** provides a method to diagnose code coverage.
+This argument turns on special compiler flags including reduced optimization.
+This option is currently only available with the gnu compiler and on a few systems.
+To use, submit a full test suite with the gnu compiler and the ``--codecov`` argument.
+The test suite will run and a report will be generated and uploaded to 
+the `codecov.io site <https://codecov.io/gh/CICE-Consortium/Icepack>`_ by the **report_codecov.csh** script.  
+This is just a diagnostic test
+and should not be treated as a test of the model due to changes in the compiler
+settings.  A sample job submission would look like ::
+
+$ ./icepack.setup -m conrad -e gnu --suite base_suite,travis_suite,quick_suite --testid cc01 --codecov
+

--- a/icepack.setup
+++ b/icepack.setup
@@ -226,11 +226,11 @@ while (1)
   else
     shift argv
     if ( $#argv < 1 ) then
-      echo "${0}: ERROR1 in $option"
+      echo "${0}: ERROR in $option, unsupported or missing an argument"
       exit -1
     endif
-    if ($argv[1] =~ $dash* ) then
-      echo "${0}: ERROR2 in $option"
+    if ("$argv[1]" =~ "$dash*" ) then
+      echo "${0}: ERROR in $option, possibly missing an argument"
       exit -1
     endif
 

--- a/icepack.setup
+++ b/icepack.setup
@@ -34,6 +34,8 @@ set stime = `date -u "+%H%M%S"`
 set docase = 0
 set dotest = 0
 set dosuite = 0
+set codecov = 0       # code coverage measurement and reporting
+set codecovflag = false
 
 if ($#argv < 1) then
   set helpheader = 1
@@ -78,7 +80,7 @@ SYNOPSIS
 
     --suite SUITE[,SUITE2] -m MACH --testid ID 
         [-e ENV1,ENV2][--acct ACCT][--bdir DIR][--bgen DIR]
-        [--bcmp DIR][--tdir PATH][--report]
+        [--bcmp DIR][--tdir PATH][--report][--codecov]
 
 DESCRIPTION
     --help, -h : help
@@ -104,6 +106,8 @@ DESCRIPTION
     --testid   : test ID, user-defined id for testing (REQUIRED with --test or --suite)
     --diff     : generate comparison against another case
     --report   : automatically post results when tests are complete
+    --codecov  : generate and report test coverage metrics when tests are complete,
+                 requires GNU compiler (--env gnu)
 
 EXAMPLES
     icepack.setup -c caseB -m gordon -e cray -s diag1,debug
@@ -213,6 +217,11 @@ while (1)
     set report = 1
     shift argv
 
+  else if ("$option" == "--codecov") then
+    set codecov = 1
+    set codecovflag = true
+    shift argv
+     
 # arguments with settings
   else
     shift argv
@@ -286,7 +295,30 @@ if (${dosum} > 1) then
   exit -1
 endif
 
+if ($codecov == 1 && $report == 1) then
+  echo "${0}: ERROR in arguments, not recommmended to set both --codecov and --report"
+  exit -1
+endif
+
+if ($codecov == 1 && "$compilers" != "gnu") then
+  echo "${0}: ERROR in arguments, must use --env gnu with --codecov"
+  exit -1
+endif
+
+if ($codecov == 1 && `where curl` == "" && `where wget` == "") then
+  echo "${0}: ERROR 'curl' or 'wget' is required for --codecov"
+  exit -1
+endif
+
 if (${dosuite} == 0) then
+  if ($report == 1) then
+    echo "${0}: ERROR in arguments, must use --suite with --report"
+    exit -1
+  endif
+  if ($codecov == 1) then
+    echo "${0}: ERROR in arguments, must use --suite with --coverage"
+    exit -1
+  endif
   if ("$compilers" =~ "*,*") then
     echo "${0}: ERROR in arguments, cannot set multiple compilers without --suite"
     exit -1
@@ -366,10 +398,7 @@ else
   endif
   cp -f ${ICE_SCRIPTS}/tests/report_results.csh ${tsdir}
   cp -f ${ICE_SCRIPTS}/tests/timeseries.csh ${tsdir}
-
-  if ($report == 1) then
-    cp -f ${ICE_SCRIPTS}/tests/poll_queue.csh ${tsdir}
-  endif
+  cp -f ${ICE_SCRIPTS}/tests/poll_queue.csh ${tsdir}
 
 cat >! ${tsdir}/suite.run << EOF0
 #!/bin/csh -f
@@ -395,6 +424,7 @@ echo "#hash = ${hash}" >> results.log
 echo "#hshs = ${shhash}" >> results.log
 echo "#hshu = ${hashuser}" >> results.log
 echo "#hshd = ${hashdate}" >> results.log
+echo "#suit = ${testsuite}" >> results.log
 echo "#date = ${cdate}" >> results.log
 echo "#time = ${ctime}" >> results.log
 echo "#mach = ${machine}" >> results.log
@@ -403,8 +433,19 @@ echo "#vers = ${vers}" >> results.log
 echo "#------- " >> results.log
 EOF0
 
+cat >! ${tsdir}/report_codecov.csh << EOF0
+#!/bin/csh -f
+
+setenv CODECOV_TOKEN "df12b574-8dce-439d-8d3b-ed7428d7598a"
+set report_name = "${shhash}:${branch}:${machine} ${testsuite}"
+
+set use_curl = 1
+
+EOF0
+
   chmod +x ${tsdir}/suite.run
   chmod +x ${tsdir}/results.csh
+  chmod +x ${tsdir}/report_codecov.csh
 
 endif
 
@@ -559,6 +600,8 @@ foreach compiler ( $ncompilers )
       endif
     endif
 
+    set rundir = ${ICE_MACHINE_WKDIR}/${casename}
+
     #------------------------------------------------------------
     # Compute a default blocksize
 
@@ -591,6 +634,7 @@ foreach compiler ( $ncompilers )
     echo "ICE_CASEDIR  = ${casedir}"
     echo "ICE_MACHINE  = ${machine}"
     echo "ICE_COMPILER = ${compiler}"
+    echo "ICE_RUNDIR   = ${rundir}"
 
     #------------------------------------------------------------
     # Copy in and update icepack.settings and icepack_in files
@@ -636,7 +680,7 @@ setenv ICE_CASEDIR  ${casedir}
 setenv ICE_MACHINE  ${machine}
 setenv ICE_COMPILER ${compiler}
 setenv ICE_MACHCOMP ${machcomp}
-setenv ICE_RUNDIR   ${ICE_MACHINE_WKDIR}/${casename}
+setenv ICE_RUNDIR   ${rundir}
 setenv ICE_GRID     ${grid}
 setenv ICE_NXGLOB   ${ICE_DECOMP_NXGLOB}
 setenv ICE_NTASKS   ${task}
@@ -651,6 +695,7 @@ setenv ICE_TESTNAME ${testname_noid}
 setenv ICE_BFBCOMP  ${fbfbcomp}
 setenv ICE_ACCOUNT  ${acct}
 setenv ICE_QUEUE    ${queue}
+setenv ICE_CODECOV  ${codecovflag}
 EOF1
 
     if (${sets} != "") then
@@ -787,6 +832,17 @@ cat >> ${tsdir}/results.csh << EOF
 cat ${testname_base}/test_output >> results.log
 EOF
 
+cat >> ${tsdir}/report_codecov.csh << EOF
+
+cp ${rundir}/compile/*.{gcno,gcda} ${ICE_SANDBOX}/columnphysics/
+if ( \${use_curl} == 1 ) then
+  bash -c "bash <(curl -s https://codecov.io/bash) -n '\${report_name}'"
+else
+  bash -c "bash <(wget -O - https://codecov.io/bash) -n '\${report_name}'"
+endif
+rm ${ICE_SANDBOX}/columnphysics/*.{gcno,gcda}
+EOF
+
 cat >> ${tsdir}/suite.run << EOF
 cd ${testname_base}
 ./icepack.build
@@ -844,6 +900,11 @@ EOF
     ./poll_queue.csh
     ./results.csh
     ./report_results.csh
+  endif
+  if ($codecov == 1) then
+    echo "Generating codecov reports"
+    ./poll_queue.csh
+    ./report_codecov.csh
   endif
   cd ${ICE_SANDBOX}
 

--- a/icepack.setup
+++ b/icepack.setup
@@ -316,7 +316,7 @@ if (${dosuite} == 0) then
     exit -1
   endif
   if ($codecov == 1) then
-    echo "${0}: ERROR in arguments, must use --suite with --coverage"
+    echo "${0}: ERROR in arguments, must use --suite with --codecov"
     exit -1
   endif
   if ("$compilers" =~ "*,*") then


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Add code coverage capability, follow on from PR #202 
- [X] Developer(s): 
    @anders-dc, @apcraig 
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
     #5989276fb, https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

A new flag, --codecov has been added to the icepack.setup arguments.  This turns on the code coverage compiler options and then runs the report_codecov.csh script when the test runs are complete.  Results are posted the codecov website, [https://codecov.io/gh/CICE-Consortium/Icepack](https://codecov.io/gh/CICE-Consortium/Icepack).  This is currently only supported with the gnu compiler.  In addition, optimization of all tests is reduced to -O0, so this should not be done as part of standard testing, but it should be considered a separate tool and run as a separate suite.

This has been tested on conrad and gaffney with success.  It should also work on gordon and koehr.  It ran fine on onyx, but the reporting failed there for unknown reasons.  It was tested on travis before, but I have turned off the capability in travis testing because of the reduced optimization.  In fact, we just need this to work on a few platforms and only need to run this on one platform that supports the gnu compiler and can runs the full test suite.

My proposal is that I add a weekly code coverage run on conrad.  This would be just with the gnu compiler and for the current master.  This would just document the testing coverage of the full test suite on master once a week for reference.  There is a new git badge added that should point to the codecov output.  We'll have to see if that is setup properly and/or how to setup the integration with git once it's all on master.  I view this tool as largely an internal tool to verify we are adequately testing, I'm not sure it has to be particularly public.  But at the same time, it's fine to indicate that we are diagnosing coverage testing and we want to be able to check it with a click relatively easily.  We probably should also add a link on the resource index page once we verify things are working correctly, and we understand the link.
