### PR TITLE
Update travisCI to xenial build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 
+dist: xenial
+
 sudo: false
 
 addons:
@@ -9,8 +11,7 @@ addons:
     packages:
       - tcsh
       - pkg-config
-      - netcdf-bin
-      - libnetcdf-dev
+      - netcdf-bin libnetcdf-dev libnetcdff-dev
       - gfortran
       - gcc
       - wget


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update travisCI to xenial build environment
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested on conrad+gnu, https://github.com/CICE-Consortium/Test-Results/wiki/2a14a4cf9c.conrad.gnu.190729.193832
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

Migrate to xenial to be consistent with CICE.  Inherent difference in trusty and xenial netcdf packages.  Icepack does not use netcdf but may in the future for some test configurations.