### PR TITLE
Add conda environment, fix Makefile and Macros, implement `-nomodules`

### DIFF
--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -110,10 +110,6 @@ db_flags:
 # the needed macros
 #-------------------------------------------------------------------------------
 
-ifndef $(CFLAGS_HOST)
-  CFLAGS_HOST :=
-endif
-
 $(DEPGEN): $(ICE_CASEDIR)/makdep.c
 	$(SCC) -o $@ $(CFLAGS_HOST) $<
 

--- a/configuration/scripts/icepack.batch.csh
+++ b/configuration/scripts/icepack.batch.csh
@@ -143,6 +143,11 @@ cat >> ${jobfile} << EOFB
 # nothing to do
 EOFB
 
+else if (${ICE_MACHINE} =~ conda*) then
+cat >> ${jobfile} << EOFB
+# nothing to do
+EOFB
+
 else
   echo "${0} ERROR: ${ICE_MACHINE} unknown"
   exit -1

--- a/configuration/scripts/machines/Macros.cheyenne_intel
+++ b/configuration/scripts/machines/Macros.cheyenne_intel
@@ -39,14 +39,14 @@ LIB_MPI := $(IMPILIBDIR)
 #SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff -L$(LIB_PNETCDF) -lpnetcdf -lgptl
 SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
 
-ifeq ($(compile_threaded), true) 
+ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -qopenmp 
    CFLAGS += -qopenmp 
    FFLAGS += -qopenmp 
 endif
 
 ### if using parallel I/O, load all 3 libraries.  PIO must be first!
-ifeq ($(IO_TYPE), pio)
+ifeq ($(ICE_IOTYPE), pio)
    PIO_PATH:=/glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/lib
    INCLDIR += -I/glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/include
    SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpiof

--- a/configuration/scripts/machines/Macros.conda_linux
+++ b/configuration/scripts/machines/Macros.conda_linux
@@ -1,0 +1,35 @@
+#==============================================================================
+# Makefile macros for conda environment, GNU/Linux systems
+#==============================================================================
+
+# Preprocessor macros
+CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
+
+# Flags for the C compiler
+CFLAGS     := -c -O2
+
+# Flags for the Fortran compiler
+FREEFLAGS  := -ffree-form
+FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
+
+# Additional flags for the Fortran compiler when compiling in debug mode
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+else
+  FFLAGS   += -O2
+endif
+
+# C and Fortran compilers
+SCC   := gcc
+SFC   := gfortran
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
+
+# Necessary flag to compile with OpenMP support
+ifeq ($(ICE_THREADED), true)
+   LDFLAGS += -fopenmp
+   CFLAGS  += -fopenmp
+   FFLAGS  += -fopenmp
+endif
+

--- a/configuration/scripts/machines/Macros.conda_macos
+++ b/configuration/scripts/machines/Macros.conda_macos
@@ -1,0 +1,38 @@
+#==============================================================================
+# Makefile macros for conda environment, macOS systems
+#==============================================================================
+
+# Preprocessor macros
+CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
+
+# Flags for the C compiler
+CFLAGS     := -c -O2
+
+# Flags for the Fortran compiler
+FREEFLAGS  := -ffree-form
+FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
+
+# Additional flags for the Fortran compiler when compiling in debug mode
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+else
+  FFLAGS   += -O2
+endif
+
+# C and Fortran compilers
+SCC   := clang
+SFC   := gfortran
+CC := $(SCC)
+FC := $(SFC)
+LD := $(FC)
+
+# Location of the system C header files (required on recent macOS to compile makdep)
+CFLAGS_HOST = -isysroot$(shell xcrun --show-sdk-path)
+
+# Necessary flag to compile with OpenMP support
+ifeq ($(ICE_THREADED), true)
+   LDFLAGS += -fopenmp
+   CFLAGS  += -fopenmp
+   FFLAGS  += -fopenmp
+endif
+

--- a/configuration/scripts/machines/Macros.testmachine_intel
+++ b/configuration/scripts/machines/Macros.testmachine_intel
@@ -38,14 +38,14 @@ LIB_MPI := $(IMPILIBDIR)
 
 SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff -L$(LIB_PNETCDF) -lpnetcdf -lgptl
 
-ifeq ($(compile_threaded), true) 
+ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -openmp 
    CFLAGS += -openmp 
    FFLAGS += -openmp 
 endif
 
 ### if using parallel I/O, load all 3 libraries.  PIO must be first!
-ifeq ($(IO_TYPE), pio)
+ifeq ($(ICE_IOTYPE), pio)
    PIO_PATH:=/glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/lib
    INCLDIR += -I/glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/include
    SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpiof

--- a/configuration/scripts/machines/env.conda_linux
+++ b/configuration/scripts/machines/env.conda_linux
@@ -1,0 +1,41 @@
+#!/bin/csh -f
+
+set inp = "undefined"
+if ($#argv == 1) then
+  set inp = $1
+endif
+
+if ("$inp" != "-nomodules") then
+
+# Init conda
+if ! $?CONDA_EXE then
+  echo ""
+  echo "${0}: conda executable not found, see the Icepack documentation for how to initialize your login shell to use conda"
+  echo ""
+  exit 1
+endif
+source `$CONDA_EXE info --base`/etc/profile.d/conda.csh
+# Activate "icepack" conda environment
+conda activate icepack
+if $status then
+  echo ""
+  echo "${0}: 'icepack' conda environment not found, see the Icepack documentation for how to create the conda icepack env"
+  echo ""
+  exit 1
+endif
+
+endif
+
+setenv ICE_MACHINE_ENVNAME conda
+setenv ICE_MACHINE_COMPILER linux
+setenv ICE_MACHINE_MAKE make
+setenv ICE_MACHINE_WKDIR  $HOME/icepack-dirs/runs
+setenv ICE_MACHINE_INPUTDATA $HOME/icepack-dirs/input
+setenv ICE_MACHINE_BASELINE $HOME/icepack-dirs/baseline
+setenv ICE_MACHINE_SUBMIT " "
+setenv ICE_MACHINE_TPNODE 4
+setenv ICE_MACHINE_ACCT P0000000
+setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_BLDTHRDS 4
+setenv ICE_MACHINE_QSTAT " "
+

--- a/configuration/scripts/machines/env.conda_macos
+++ b/configuration/scripts/machines/env.conda_macos
@@ -1,0 +1,41 @@
+#!/bin/csh -f
+
+set inp = "undefined"
+if ($#argv == 1) then
+  set inp = $1
+endif
+
+if ("$inp" != "-nomodules") then
+
+# Init conda
+if ! $?CONDA_EXE then
+  echo ""
+  echo "${0}: conda executable not found, see the Icepack documentation for how to initialize your login shell to use conda"
+  echo ""
+  exit 1
+endif
+source `$CONDA_EXE info --base`/etc/profile.d/conda.csh
+# Activate "icepack" conda environment
+conda activate cice
+if $status then
+  echo ""
+  echo "${0}: 'cice' conda environment not found, see the Icepack documentation for how to create the conda icepack env"
+  echo ""
+  exit 1
+endif
+
+endif
+
+setenv ICE_MACHINE_ENVNAME conda
+setenv ICE_MACHINE_COMPILER macos
+setenv ICE_MACHINE_MAKE make
+setenv ICE_MACHINE_WKDIR  $HOME/icepack-dirs/runs
+setenv ICE_MACHINE_INPUTDATA $HOME/icepack-dirs/input
+setenv ICE_MACHINE_BASELINE $HOME/icepack-dirs/baseline
+setenv ICE_MACHINE_SUBMIT " "
+setenv ICE_MACHINE_TPNODE 4
+setenv ICE_MACHINE_ACCT P0000000
+setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_BLDTHRDS 4
+setenv ICE_MACHINE_QSTAT " "
+

--- a/configuration/scripts/machines/environment.yml
+++ b/configuration/scripts/machines/environment.yml
@@ -1,0 +1,11 @@
+name: icepack
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+# Build dependencies
+  - compilers
+  - make
+# Python dependencies for building the HTML documentation
+  - sphinx
+  - sphinxcontrib-bibtex

--- a/configuration/scripts/setup_run_dirs.csh
+++ b/configuration/scripts/setup_run_dirs.csh
@@ -1,7 +1,7 @@
 #! /bin/csh -f
 
 source ./icepack.settings
-source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} || exit 2
+source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} -nomodules || exit 2
 
 if !(-d ${ICE_RUNDIR}) then
   echo "mkdir ${ICE_RUNDIR}"

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -359,6 +359,16 @@ On GNU/Linux:
   # Close and reopen your shell
   
 
+Note: on some Linux distributions (including Ubuntu and its derivatives), the csh shell that comes with the system is not compatible with conda.
+You will need to install the tcsh shell (which is backwards compatible with csh), and configure your system to use tcsh as csh:
+
+.. code-block:: bash
+
+  # Install tcsh
+  sudo apt-get install tcsh
+  # Configure your system to use tcsh as csh
+  sudo update-alternatives --set csh /bin/tcsh
+
 .. _init_shell:
 
 Initializing your shell for use with conda

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -310,6 +310,259 @@ There is also an option (``--queue``) in **icepack.setup** to define the queue n
 The order of precedent is **icepack.setup** command line option, 
 **.cice\_queue** setting, and then value in the **env.[machine]** file.
 
+.. _laptops:
+
+Porting to Laptop or Personal Computers
+-----------------------------------------
+To get the required software necessary to build and run Icepack, a `conda <https://docs.conda.io/en/latest/>`_ environment file is available at :
+
+``configuration/scripts/machines/environment.yml``.
+
+This configuration is supported by the Consortium on a best-effort basis on macOS and GNU/Linux. It is untested under Windows, but might work using the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_.
+
+Once you have installed Miniconda and created the ``icepack`` conda environment by following the procedures in this section, Icepack should run on your machine without having to go through the formal :ref:`porting` process outlined above.
+
+.. _install_miniconda:
+
+Installing Miniconda
+~~~~~~~~~~~~~~~~~~~~
+
+We recommend the use of the `Miniconda distribution <https://docs.conda.io/en/latest/miniconda.html>`_ to create a self-contained conda environment from the ``environment.yml`` file.
+This process has to be done only once.
+If you do not have Miniconda or Anaconda installed, you can install Miniconda by following the `official instructions  <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_, or with these steps:
+
+On macOS:
+
+.. code-block:: bash
+
+  # Download the Miniconda installer to ~/Downloads/miniconda.sh
+  curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o ~/Downloads/miniconda.sh
+  # Install Miniconda
+  bash ~/Downloads/miniconda.sh
+  
+  # Follow the prompts
+  
+  # Close and reopen your shell
+
+
+On GNU/Linux:
+
+.. code-block:: bash
+
+  # Download the Miniconda installer to ~/miniconda.sh
+  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+  # Install Miniconda
+  bash ~/miniconda.sh
+  
+  # Follow the prompts
+  
+  # Close and reopen your shell
+  
+
+.. _init_shell:
+
+Initializing your shell for use with conda
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We recommend initializing your default shell to use conda.
+This process has to be done only once.
+
+The Miniconda installer should ask you if you want to do that as part of the installation procedure.
+If you did not answer "yes", you can use one of the following procedures depending on your default shell.
+Bash should be your default shell if you are on macOS (10.14 and older) or GNU/Linux.
+
+Note: answering "yes" during the Miniconda installation procedure will only initialize the Bash shell for use with conda.
+
+If your Mac has macOS 10.15 or higher, your default shell is Zsh. 
+
+These instructions make sure that the ``conda`` command is available when you start your shell by modifying your shell's startup file.
+Also, they make sure not to activate the "base" conda environment when you start your shell.
+This conda environment is created during the Miniconda installation but is not used for Icepack. 
+
+For Bash:
+
+.. code-block:: bash
+
+  # Install miniconda as indicated above, then initialize your shell to use conda:
+  source $HOME/miniconda3/bin/activate
+  conda init bash
+  
+  # Don't activate the "base" conda environment on shell startup
+  conda config --set auto_activate_base false
+  
+  # Close and reopen your shell
+
+For Zsh (Z shell):
+
+.. code-block:: bash
+
+  # Initialize Zsh to use conda
+  source $HOME/miniconda3/bin/activate
+  conda init zsh
+  
+  # Don't activate the "base" conda environment on shell startup
+  conda config --set auto_activate_base false
+  
+  # Close and reopen your shell
+
+For tcsh:
+
+.. code-block:: bash
+  
+  # Install miniconda as indicated above, then initialize your shell to use conda:
+  source $HOME/miniconda3/etc/profile.d/conda.csh
+  conda init tcsh
+  
+  # Don't activate the "base" conda environment on shell startup
+  conda config --set auto_activate_base false
+  
+  # Close and reopen your shell
+
+For fish:
+
+.. code-block:: bash
+  
+  # Install miniconda as indicated above, then initialize your shell to use conda:
+  source $HOME/miniconda3/etc/fish/conf.d/conda.fish
+  conda init fish
+  
+  # Don't activate the "base" conda environment on shell startup
+  conda config --set auto_activate_base false
+  
+  # Close and reopen your shell
+
+For xonsh:
+
+.. code-block:: bash
+
+  # Install miniconda as indicated above, then initialize your shell to use conda:
+  source-bash $HOME/miniconda3/bin/activate
+  conda init xonsh
+  
+  # Don't activate the "base" conda environment on shell startup
+  conda config --set auto_activate_base false
+  
+  # Close and reopen your shell
+
+.. _init_shell_manually:
+
+Initializing your shell for conda manually
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you prefer not to modify your shell startup files, you will need to run the appropriate ``source`` command below (depending on your default shell) before using any conda command, and before compiling and running Icepack.
+These instructions make sure the ``conda`` command is available for the duration of your shell session.
+
+For Bash and Zsh:
+
+.. code-block:: bash
+
+  # Initialize your shell session to use conda:
+  source $HOME/miniconda3/bin/activate
+
+For tcsh:
+
+.. code-block:: bash
+  
+  # Initialize your shell session to use conda:
+  source $HOME/miniconda3/etc/profile.d/conda.csh
+
+
+For fish:
+
+.. code-block:: bash
+  
+  # Initialize your shell session to use conda:
+  source $HOME/miniconda3/etc/fish/conf.d/conda.fish
+
+For xonsh:
+
+.. code-block:: bash
+
+  # Initialize your shell session to use conda:
+  source-bash $HOME/miniconda3/bin/activate
+
+
+.. _create_conda_env:
+
+Creating Icepack directories and the conda environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The conda configuration expects some directories and files to be present at ``$HOME/icepack-dirs``:
+
+.. code-block:: bash
+
+  cd $HOME
+  mkdir -p icepack-dirs/runs icepack-dirs/baseline icepack-dirs/input
+  # Download the required forcing from https://github.com/CICE-Consortium/Icepack/wiki/Icepack-Input-Data
+  # and untar it at $HOME/icepack-dirs/input
+
+This step needs to be done only once.
+
+If you prefer that some or all of the Icepack directories be located somewhere else, you can create a symlink from your home to another location:
+
+.. code-block:: bash
+
+  
+  # Create the Icepack directories at your preferred location
+  cd ${somewhere}
+  mkdir -p icepack-dirs/runs icepack-dirs/baseline icepack-dirs/input
+  # Download the required forcing from https://github.com/CICE-Consortium/Icepack/wiki/Icepack-Input-Data
+  # and untar it at icepack-dirs/input
+  
+  # Create a symlink to icepack-dirs in your $HOME
+  cd $HOME
+  ln -s ${somewhere}/icepack-dirs icepack-dirs
+
+Note: if you wish, you can also create a complete machine port for your computer by leveraging the conda configuration as a starting point. See :ref:`porting`.
+
+Next, create the "icepack" conda environment from the ``environment.yml`` file:
+
+.. code-block:: bash
+
+  conda env create -f configuration/scripts/machines/environment.yml
+
+This step needs to be done only once.
+
+.. _using_conda_env:
+
+Using the conda configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Follow the general instructions in :ref:`overview`, using the ``conda`` machine name and ``macos`` or ``linux`` as compiler names.
+
+On macOS:
+
+.. code-block:: bash
+
+  ./icepack.setup -m conda -e macos -c ~/icepack-dirs/cases/case1
+  cd ~/icepack-dirs/cases/case1
+  ./icepack.build
+  ./icepack.run
+
+On GNU/Linux:
+
+.. code-block:: bash
+
+  ./icepack.setup -m conda -e linux -c ~/icepack-dirs/cases/case1
+  cd ~/icepack-dirs/cases/case1
+  ./icepack.build
+  ./icepack.run
+
+A few notes about the conda configuration:
+
+- This configuration always runs the model interactively, such that ``./icepack.run`` and ``./icepack.submit`` are the same.
+- You should not update the packages in the ``icepack`` conda environment, nor install additional packages.
+- It is not recommeded to run other test suites than ``quick_suite`` or ``travis_suite`` on a personal computer.
+- The conda environment is automatically activated when compiling or running the model using the ``./icepack.build`` and ``./icepack.run`` scripts in the case directory. These scripts source the file ``env.conda_{linux.macos}``, which calls ``conda activate icepack``.
+- The environment also contains the Sphinx package necessesary to build the HTML documentation. For this use case you must manually activate the environment:
+
+  .. code-block:: bash
+  
+    cd doc
+    conda activate icepack
+    make html
+    # Open build/html/index.html in your browser
+    conda deactivate  # to deactivate the environment
+
 .. _force:
 
 Forcing data

--- a/icepack.setup
+++ b/icepack.setup
@@ -558,7 +558,7 @@ foreach compiler ( $ncompilers )
     end
 
     cd ${casedir}
-    source ./env.${machcomp} || exit 2
+    source ./env.${machcomp} -nomodules || exit 2
 
     set quietmode = false
     if ($?ICE_MACHINE_QUIETMODE) then
@@ -763,14 +763,14 @@ EOF2
     ${casescr}/parse_settings.sh icepack.settings ${fsmods}
     ${casescr}/parse_namelist.sh icepack_in ${fimods}
     source ./icepack.settings
-    source ./env.${machcomp} || exit 2
+    source ./env.${machcomp} -nomodules || exit 2
     ${casescr}/parse_namelist_from_settings.sh icepack_in icepack.settings
 
     #------------------------------------------------------------
     # Generate run script
 
     source ./icepack.settings
-    source ./env.${machcomp} || exit 2
+    source ./env.${machcomp} -nomodules || exit 2
 
     ${casescr}/icepack.run.setup.csh
     if ($status != 0) then


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
   Add a conda environment for macOS and Linux, mirroring CICE-Consortium/CICE#393
- [x] Developer(s): 
    P. Blain
- [x] Suggest PR reviewers from list in the column to the right.
@apcraig
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Did not run the tests suite. I tested that the procedure works on Mac and Linux.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level 
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

This PR implements the conda environment for Icepack. The `environment.yml` file is simpler since Icepack has less dependencies. A few points:

- I had to fix the Makefile to remove the faulty logic around `CFLAGS_HOST`, as in CICE-Consortium/CICE#393
- I had to modify `icepack.setup` and `setup_run_dirs.csh` to implement the `-nomodules` logic which was already used by some env files but was ineffective.
- As discussed yesterday I also fixed the Macros files for cheyenne and testmachine to use the correct environment variables for threading and PIO, as done in CICE-Consortium/CICE#396. Note that I did not change `icepack.launch.csh` to use `omplace` on cheyenne, as was done in CICE-Consortium/CICE#396. @apcraig I'll let you push directly to this branch if you want to add that, although I think it can be left for later as all test suites have `1x1` PEs so merging this PR will not switch on any threading on cheyenne.