### PR TITLE
Fix nt_zbgc_frac

### DIFF
--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -1311,6 +1311,7 @@
       nt_bgc_DMS    = 0
       nt_bgc_PON    = 0
       nt_bgc_hum    = 0
+      nt_zbgc_frac  = 0
 
       !-----------------------------------------------------------------
       ! Define array parameters
@@ -1700,7 +1701,6 @@
          endif      ! tr_zaero
 
 !echmod keep trcr indices etc here but move zbgc_frac_init, zbgc_init_frac, tau_ret, tau_rel to icepack
-         nt_zbgc_frac = 0
          if (nbtrcr > 0) then
             nt_zbgc_frac = ntrcr + 1
             ntrcr = ntrcr + nbtrcr


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Make sure nt_zbgc_frac is initialized when z_tracers is .false.
- [X] Developer(s): 
David Bailey (dabail10)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Ran base_suite.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
Just changes the printed value for nt_zbgc_frac when z_tracers is .false.
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please provide any additional information or relevant details below:
