### PR TITLE
Add initialization of n_aero to icepack driver

### DIFF
--- a/configuration/driver/icedrv_init.F90
+++ b/configuration/driver/icedrv_init.F90
@@ -674,6 +674,7 @@
          write(nu_diag,1020) 'nslyr   = ', nslyr
          write(nu_diag,1020) 'nblyr   = ', nblyr
          write(nu_diag,1020) 'nfsd    = ', nfsd
+         write(nu_diag,1020) 'n_aero  = ', n_aero
          write(nu_diag,*)' '
          write(nu_diag,1020) 'nx      = ', nx
          write(nu_diag,*)' '
@@ -736,7 +737,7 @@
            wave_spec_type_in=wave_spec_type, wave_spec_in=wave_spec)
       call icepack_init_tracer_sizes(ntrcr_in=ntrcr, &
            ncat_in=ncat, nilyr_in=nilyr, nslyr_in=nslyr, nblyr_in=nblyr, &
-           nfsd_in=nfsd)
+           nfsd_in=nfsd, n_aero_in=n_aero)
       call icepack_init_tracer_flags(tr_iage_in=tr_iage, &
            tr_FY_in=tr_FY, tr_lvl_in=tr_lvl, tr_aero_in=tr_aero, &
            tr_pond_in=tr_pond, tr_pond_cesm_in=tr_pond_cesm, &


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Add initialization of n_aero in icepack driver
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested in icepack on conrad with 4 compilers.  All tests pass EXCEPT the pondcesm test case indicates non-bit-for-bit vs the baseline.  I have compared the ice_diag files for all pondcesm cases vs the baseline, and they are bit-for-bit, but the restart file (which is what is compared in the test) is not.  I suspect something is written slightly different into the restart file that does not affect answers.  This seems to happen just for the pondcesm case.  I don't understand why.  Because the restart files are binary, it's not easy to identify the differences.  But I think we can accept this since the ice_diag files are identical.
https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#7259556232cebf37f4c9b42b4ba0b866a07d196b 
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

