### PR TITLE
Update albedo initialization for identical order of operations

### DIFF
--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -175,8 +175,6 @@
          Iswabsn(:,:,:) = c0
          Sswabsn(:,:,:) = c0
 
-      !$OMP PARALLEL DO PRIVATE(i,n, &
-      !$OMP                     l_print_point)
          do i = 1, nx
 
             l_print_point = .false.
@@ -287,11 +285,14 @@
                enddo
             endif
 
+         enddo
+
       !-----------------------------------------------------------------
       ! Aggregate albedos 
       !-----------------------------------------------------------------
 
-            do n = 1, ncat
+         do n = 1, ncat
+            do i = 1, nx
                
                if (aicen(i,n) > puny) then
                   
@@ -311,8 +312,10 @@
                   snowfrac(i) = snowfrac(i) + snowfracn(i,n)*aicen(i,n)
                
                endif ! aicen > puny
+            enddo  ! i
+         enddo   ! ncat
 
-            enddo  ! ncat
+         do i = 1, nx
 
       !----------------------------------------------------------------
       ! Store grid box mean albedos and fluxes before scaling by aice
@@ -1238,6 +1241,7 @@
       ntd = 0                    ! if nt_fbri /= 0 then use fbri dependency
       if (nt_fbri == 0) ntd = -1 ! otherwise make tracers depend on ice volume
 
+      nt_bgc_S = 0
       if (solve_zsal) then       ! .true. only if tr_brine = .true.
           nt_bgc_S = ntrcr + 1
           ntrcr = ntrcr + nblyr

--- a/configuration/driver/icedrv_restart.F90
+++ b/configuration/driver/icedrv_restart.F90
@@ -328,7 +328,7 @@
          work2              ! input array (real, 8-byte)
 
       real (kind=dbl_kind) :: &
-        minw, maxw          ! diagnostics
+        minw, maxw, sumw    ! diagnostics
 
       character(len=*), parameter :: subname='(read_restart_field)'
 
@@ -339,7 +339,8 @@
 
       minw = minval(work)
       maxw = maxval(work)
-      write(nu_diag,*) minw, maxw
+      sumw = sum(work)
+      write(nu_diag,*) subname, minw, maxw, sumw
       
       end subroutine read_restart_field
       
@@ -367,12 +368,20 @@
       real (kind=dbl_kind), dimension(nx) :: &
          work2             ! input array (real, 8-byte)
       
+      real (kind=dbl_kind) :: &
+        minw, maxw, sumw    ! diagnostics
+
       character(len=*), parameter :: subname='(write_restart_field)'
 
       do n = 1, ndim
         work2(:) = work(:,n)
         write(nu) (work2(i), i=1,nx)
       enddo
+      
+      minw = minval(work)
+      maxw = maxval(work)
+      sumw = sum(work)
+      write(nu_diag,*) subname, minw, maxw, sumw
       
       end subroutine write_restart_field
 

--- a/configuration/scripts/icepack.run.setup.csh
+++ b/configuration/scripts/icepack.run.setup.csh
@@ -72,7 +72,9 @@ echo " "
 
 if !(-d \${ICE_LOGDIR}) mkdir -p \${ICE_LOGDIR}
 cp -p \${ICE_RUNLOG_FILE} \${ICE_LOGDIR}
-cp -p ice_diag.* \${ICE_LOGDIR}
+foreach file (ice_diag.*)
+  cp -p \${file} \${ICE_LOGDIR}/\${file}.\${stamp}
+end
 
 grep ' ICEPACK COMPLETED SUCCESSFULLY' \${ICE_RUNLOG_FILE}
 if ( \$status != 0 ) then


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    fix albedo initialization which resulted in one non-exact restart
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    Tested on conrad full suite with 4 compilers, all pass, all bit-for-bit [(results)](https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#92d673e5ad3084b2aa07606e4875a3614cc675c1)
    Tested on conrad full suite with 4 compilers with iso1, all tests pass, a few tests fail regression due to compiler optimization related to iso1 change (not this PR) [results](https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#92d673e5ad3084b2aa07606e4875a3614cc675c1)
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

With the iso1 changes, one test was failing exact restart on one machine and compiler.  After some debugging, it turns out to be an order of operations issue in initialization of albedos that has been there forever but never resulted in problems with exact restart.  For whatever reason, this one test on one compiler on one machine picked it up finally.   It is fixed and the answers are also bit-for-bit with prior results.

I also fixed initialization of nt_bgc_S when solve_zsal is off.  It was not uniquely defined but this did not seem to matter to runs.  Still, it should be set.

I added some diagnostics for restart read and write to more easily confirm identical fields written and read.

I modified how the ice_diag files are saved to the log directory by attaching the run timestamp to the filenames.  This was long overdue.  Prior, runs in the same directory (including restart tests) just overwrote the files on each run.  We may want to eventually also change the way we save baselines or rename files in the run directory as this feature is only implemented in the copy of the ice_diag files to the case log directory.

I removed an OMP directive in the albedo initialization as it will not materially help performance since the code is run once.  It's also a trivially cheap piece of code.

