### PR TITLE
Update travis data download to zenodo, update conda macos CFLAGS_HOST variable 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ addons:
 
 install:
   # Fetch Icepack-specific dataset
-  - "wget ftp://ftp.cgd.ucar.edu/archive/Model-Data/CICE/Icepack_data.tar.gz &&
-    tar xvfz Icepack_data.tar.gz -C ~"
+  - "wget https://zenodo.org/record/3728287/files/Icepack_data-20200326.tar.gz &&
+    tar xvfz Icepack_data-20200326.tar.gz -C ~"
 
   # Mirror entire data folder
   #- "lftp ftp://anonymous:travis@travis-ci.org@ftp.cgd.ucar.edu 

--- a/configuration/scripts/machines/Macros.conda_macos
+++ b/configuration/scripts/machines/Macros.conda_macos
@@ -27,7 +27,12 @@ FC := $(SFC)
 LD := $(FC)
 
 # Location of the system C header files (required on recent macOS to compile makdep)
-CFLAGS_HOST = -isysroot$(shell xcrun --show-sdk-path)
+SDKPATH = $(shell xcrun --show-sdk-path)
+ifeq ($(strip $(SDKPATH)),)
+  CFLAGS_HOST := 
+else
+  CFLAGS_HOST = -isysroot $(SDKPATH)
+endif
 
 # Necessary flag to compile with OpenMP support
 ifeq ($(ICE_THREADED), true)

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -524,7 +524,7 @@ If you prefer that some or all of the Icepack directories be located somewhere e
 
 Note: if you wish, you can also create a complete machine port for your computer by leveraging the conda configuration as a starting point. See :ref:`porting`.
 
-Next, create the "icepack" conda environment from the ``environment.yml`` file:
+Next, create the "icepack" conda environment from the ``environment.yml`` file in the Icepack source code repository.  You will need to clone Icepack to run the following command:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update travis data download to zenodo
    Update conda macos CFLAGS_HOST variable to address older installs of sdk
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested on two macos systems, an older and newer one.  Works as expected on both. 
    https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#8a2ad35d51d010c6826ac5766627ab75fb17b2d9
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

This addresses [CICE #422](https://github.com/CICE-Consortium/CICE/issues/422)
Minor update in the documentation to define location of the environment.yml file at the point someone uses it.