### PR TITLE
update test reporting

### DIFF
--- a/configuration/scripts/icepack.test.setup.csh
+++ b/configuration/scripts/icepack.test.setup.csh
@@ -40,6 +40,13 @@ if ( ! -f ${ICE_RUNDIR}/icepack ) then
   exit 99
 endif
 
+# Initial test results and Reset test results for rerun
+mv -f ${ICE_CASEDIR}/test_output ${ICE_CASEDIR}/test_output.prev
+echo "#---" >! ${ICE_CASEDIR}/test_output
+cat ${ICE_CASEDIR}/test_output.prev | grep -i "${ICE_TESTNAME} build" >> ${ICE_CASEDIR}/test_output
+echo "PEND ${ICE_TESTNAME} run" >> ${ICE_CASEDIR}/test_output
+rm -f ${ICE_CASEDIR}/test_output.prev
+
 EOF2
 
 if ( -f ${ICE_SCRIPTS}/tests/test_${ICE_TEST}.script) then

--- a/configuration/scripts/tests/test_restart.script
+++ b/configuration/scripts/tests/test_restart.script
@@ -7,14 +7,6 @@ cp icepack_in icepack_in.0
 ${ICE_CASEDIR}/casescripts/parse_namelist.sh icepack_in ${ICE_CASEDIR}/casescripts/test_nml.restart1
 cp icepack_in icepack_in.1
 
-mv -f ${ICE_CASEDIR}/test_output ${ICE_CASEDIR}/test_output.prev
-cat ${ICE_CASEDIR}/test_output.prev | grep -iv "${ICE_TESTNAME} run" >! ${ICE_CASEDIR}/test_output
-mv -f ${ICE_CASEDIR}/test_output ${ICE_CASEDIR}/test_output.prev
-cat ${ICE_CASEDIR}/test_output.prev | grep -iv "${ICE_TESTNAME} test" >! ${ICE_CASEDIR}/test_output
-rm -f ${ICE_CASEDIR}/test_output.prev
-echo "RUN  ${ICE_TESTNAME} run " >> ${ICE_CASEDIR}/test_output
-echo "PEND ${ICE_TESTNAME} test " >> ${ICE_CASEDIR}/test_output
-
 ./icepack.run
 set res="$?"
 

--- a/configuration/scripts/tests/test_smoke.script
+++ b/configuration/scripts/tests/test_smoke.script
@@ -3,11 +3,6 @@
 # Run the ICEPACK model
 # icepack.run returns -1 if run did not complete successfully
 
-mv -f ${ICE_CASEDIR}/test_output ${ICE_CASEDIR}/test_output.prev
-cat ${ICE_CASEDIR}/test_output.prev | grep -iv "${ICE_TESTNAME} run" >! ${ICE_CASEDIR}/test_output
-rm -f ${ICE_CASEDIR}/test_output.prev
-echo "RUN  ${ICE_TESTNAME} run " >> ${ICE_CASEDIR}/test_output
-
 ./icepack.run
 set res="$?"
 

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -481,7 +481,11 @@ To post results, once a test suite is complete, run ``results.csh`` and
   ./results.csh
   ./report_results.csh
 
-The reporting can also be automated by adding ``--report``
+``report_results.csh`` will run ``results.csh`` by default automatically, but
+we recommmend running it manually first to verify results before publishing
+them.  ``report_results.csh -n`` will turn off automatic running of ``results.csh``.
+
+The reporting can also be automated in a test suite by adding ``--report`` to ``icepack.setup``
 ::
 
   ./icepack.setup --suite base_suite --mach conrad --env cray --testid v01a --report

--- a/icepack.setup
+++ b/icepack.setup
@@ -792,10 +792,6 @@ EOF2
         exit -1
       endif
 
-      # Initial test_output file
-      echo "#---" >! test_output
-      echo "PEND ${testname_noid} " >> test_output
-
     endif
 
     #------------------------------------------------------------
@@ -837,24 +833,55 @@ if ( ${dosuite} == 1 ) then
   # Add code to results.csh to count the number of failures
 cat >> ${tsdir}/results.csh << EOF
 cat ./results.log
-set pends = \`cat ./results.log | grep PEND | wc -l\`
-set failures = \`cat ./results.log | grep FAIL | wc -l\`
-set success = \`cat ./results.log | grep PASS | wc -l\`
-set comments = \`cat ./results.log | grep "#" | wc -l\`
-set alltotal = \`cat ./results.log | wc -l\`
+set pends     = \`cat ./results.log | grep PEND | wc -l\`
+set misses    = \`cat ./results.log | grep MISS | wc -l\`
+set failures  = \`cat ./results.log | grep FAIL | wc -l\`
+set failbuild = \`cat ./results.log | grep FAIL | grep " build " | wc -l\`
+set failrun   = \`cat ./results.log | grep FAIL | grep " run " | wc -l\`
+set failtest  = \`cat ./results.log | grep FAIL | grep " test " | wc -l\`
+set failcomp  = \`cat ./results.log | grep FAIL | grep " compare " | wc -l\`
+set failbfbc  = \`cat ./results.log | grep FAIL | grep " bfbcomp " | wc -l\`
+set failgen   = \`cat ./results.log | grep FAIL | grep " generate " | wc -l\`
+set success   = \`cat ./results.log | grep 'PASS\|COPY' | wc -l\`
+set comments  = \`cat ./results.log | grep "#" | wc -l\`
+set alltotal  = \`cat ./results.log | wc -l\`
 @ total = \$alltotal - \$comments
+@ chkcnt = \$pends + \$misses + \$failures + \$success
 
 echo "#------- " >> results.log
 echo " " >> results.log
-echo "#totl = \$total" >> results.log
+echo "#totl = \$total total" >> results.log
+echo "#chkd = \$chkcnt checked" >> results.log
 echo "#pass = \$success" >> results.log
-echo "#fail = \$failures" >> results.log
 echo "#pend = \$pends" >> results.log
+echo "#miss = \$misses" >> results.log
+echo "#fail = \$failures" >> results.log
+echo "    #failbuild = \$failbuild" >> results.log
+echo "    #failrun   = \$failrun" >> results.log
+echo "    #failtest  = \$failtest" >> results.log
+echo "    #failcomp  = \$failcomp" >> results.log
+echo "    #failbfbc  = \$failbfbc" >> results.log
+echo "    #failgen   = \$failgen" >> results.log
 
 echo ""
-echo "\$success of \$total tests PASSED"
-echo "\$failures of \$total tests FAILED"
-echo "\$pends of \$total tests PENDING"
+echo "Descriptors:"
+echo " PASS - successful completion"
+echo " COPY - previously compiled code was copied for new test"
+echo " MISS - comparison data is missing"
+echo " PEND - status is undertermined; test may still be queued, running, or timed out"
+echo " FAIL - test failed"
+echo ""
+echo "\$chkcnt measured results of \$total total results"
+echo "\$success of \$chkcnt tests PASSED"
+echo "\$pends of \$chkcnt tests PENDING"
+echo "\$misses of \$chkcnt tests MISSING data"
+echo "\$failures of \$chkcnt tests FAILED"
+#echo "  \$failbuild of \$failures FAILED build"
+#echo "  \$failrun of \$failures FAILED run"
+#echo "  \$failtest of \$failures FAILED test"
+#echo "  \$failcomp of \$failures FAILED compare"
+#echo "  \$failbfbc of \$failures FAILED bfbcomp"
+#echo "  \$failgen of \$failures FAILED generate"
 exit \$failures
 EOF
 


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update Test Reporting
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Only scripts are changing. I have done a number of tests to verify the scripts seem to behave as expected including testing the results and report_results scripts.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

This addresses [Icepack #309](https://github.com/CICE-Consortium/Icepack/issues/309).   See also [CICE #428](https://github.com/CICE-Consortium/CICE/pull/428)

- This includes an upgrade to the test reporting by removing the RUN outcome and doing a more careful job of defining and counting the results.  

- Unique filenames are now generated everytime report_results.csh is run.  Prior to this, running report_results.csh multiple times in a test suite would just overwrite the same detailed wiki page.

- report_results.csh now automatically runs results.csh.  Prior to this, it did not.  To turn off the feature, report_results.csh -n can be invoked.
