### PR TITLE
Added catch for unusual case of (hicen_init(n+1) - hicen_init(n))>0

### DIFF
--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -305,11 +305,24 @@
 
          if (hicen_init(n)   > puny .and. &
              hicen_init(n+1) > puny) then
-             ! interpolate between adjacent category growth rates
-             slope = (dhicen(n+1) - dhicen(n)) / &
+
+            if (hicen_init(n+1) - hicen_init(n))>0
+
+              ! interpolate between adjacent category growth rates
+              slope = (dhicen(n+1) - dhicen(n)) / &
                  (hicen_init(n+1) - hicen_init(n))
-             hbnew(n) = hin_max(n) + dhicen(n) &
+              hbnew(n) = hin_max(n) + dhicen(n) &
                       + slope * (hin_max(n) - hicen_init(n))
+
+            else
+
+              write(warnstr,*) subname,...
+                 'ITD Thermodynamics: hicen_init(n+1) <= hicen_init(n)'
+              call icepack_warnings_setabort(.true.)
+              call icepack_warnings_add(warnstr)
+
+            endif
+
          elseif (hicen_init(n) > puny) then ! hicen_init(n+1)=0
              hbnew(n) = hin_max(n) + dhicen(n)
          elseif (hicen_init(n+1) > puny) then ! hicen_init(n)=0

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -306,7 +306,7 @@
          if (hicen_init(n)   > puny .and. &
              hicen_init(n+1) > puny) then
 
-            if (hicen_init(n+1) - hicen_init(n))>0
+            if ((hicen_init(n+1) - hicen_init(n))>0) then
 
               ! interpolate between adjacent category growth rates
               slope = (dhicen(n+1) - dhicen(n)) / &

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -316,7 +316,7 @@
 
             else
 
-              write(warnstr,*) subname,...
+              write(warnstr,*) subname, &
                  'ITD Thermodynamics: hicen_init(n+1) <= hicen_init(n)'
               call icepack_warnings_setabort(.true.)
               call icepack_warnings_add(warnstr)


### PR DESCRIPTION
Summary: This draft pull request addresses, in part, issue https://github.com/CICE-Consortium/Icepack/issues/333, where an erroneous initial condition of (hicen_init(n+1) - hicen_init(n))=0 made its way to the thermodynamic redistribution code.   

Developers: @proteanplanet, @dabail10, @whlipscomb, @eclare108213

Testing: Testing has not been completed until feedback is obtained on whether we desire this solution to part of the referred issue.  

Changes:  The code should be BFB with this change.

Dependencies: None added.

Documentation: None needs to be added with this change.

Additional information:  Note that the issue also highlighted the problem of a CFL-like violation in ice thickness redistribution, but this PR does not address that larger science issue. Instead, the CFL-like violation is currently catered for by switching to rebinning redistribution (remap_flag = .false.) when linear redistribution occasionally breaks down.  Fixing this is a different problem.

