### PR TITLE
doc: change URL of a reference to avoid '%' character

### DIFF
--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -726,7 +726,6 @@ journal = MWR,
 volume = {123},
 number = {},
 pages = {3032-3041},
-url = {https://journals.ametsoc.org/doi/abs/10.1175/1520-0493%281995%29123%3C3032%3ATSVSIT%3E2.0.CO%3B2},
 url = {https://journals.ametsoc.org/mwr/article/123/10/3032/65380/The-Subgrid-Velocity-Scale-in-the-Bulk-Aerodynamic},
 year = {1995}
 }

--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -727,6 +727,7 @@ volume = {123},
 number = {},
 pages = {3032-3041},
 url = {https://journals.ametsoc.org/doi/abs/10.1175/1520-0493%281995%29123%3C3032%3ATSVSIT%3E2.0.CO%3B2},
+url = {https://journals.ametsoc.org/mwr/article/123/10/3032/65380/The-Subgrid-Velocity-Scale-in-the-Bulk-Aerodynamic},
 year = {1995}
 }
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    sphinxbuild complains if url includes %.  Changed url
- [ ] Developer(s): 
    Trasmussen
- [ ] Suggest PR reviewers from list in the column to the right.
 @eclare108213 @apcraig 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    sphinx build work
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [ x] more substantial (could not create doc for latex
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [x ] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [ ] Please provide any additional information or relevant details below:

This is needed to make the latex target of the documentation Makefile work