### PR TITLE
Add ustar_prev to while loop in icepack_atmo

### DIFF
--- a/columnphysics/icepack_atmo.F90
+++ b/columnphysics/icepack_atmo.F90
@@ -271,6 +271,8 @@
 
       k = 1
       do while (abs(ustar - ustar_prev)/ustar > atmiter_conv .and. k <= natmiter)
+         k = k + 1
+         ustar_prev = ustar
 
          ! compute stability & evaluate all stability functions
          hol = vonkar * gravit * zlvl &
@@ -301,7 +303,6 @@
          tstar = rh * delt
          qstar = re * delq
 
-         k = k + 1
       enddo                     ! end iteration
 
       if (calc_strair) then


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>

This adds a necessary line for checking for convergence of the ustar loop in icepack_atmo that is missing.
Developer:  @proteanplanet 
Suggested Reviewers: @eclare108213 @dabail10 

This is a non-BFB change. There are no dependencies, and no new test cases are added.  Documentation is unchanged.
