### PR TITLE
Moved floediam and hfrazilmin to icepack_parameters

### DIFF
--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -96,6 +96,8 @@
 !-----------------------------------------------------------------------
 
       real (kind=dbl_kind), public :: &
+         floediam  = 300.0_dbl_kind   ,&! effective floe diameter for lateral melt (m)
+         hfrazilmin = 0.05_dbl_kind   ,&! min thickness of new frazil ice (m)
          cp_ice    = 2106._dbl_kind   ,&! specific heat of fresh ice (J/kg/K)
          cp_ocn    = 4218._dbl_kind   ,&! specific heat of ocn    (J/kg/K)
                                         ! freshwater value needed for enthalpy
@@ -131,7 +133,6 @@
          dSdt_slow_mode    = -1.5e-7_dbl_kind,&! slow mode drainage strength (m s-1 K-1)
          phi_c_slow_mode   =    0.05_dbl_kind,&! critical liquid fraction porosity cutoff
          phi_i_mushy       =    0.85_dbl_kind  ! liquid fraction of congelation ice
-
 
       integer (kind=int_kind), public :: &
          ktherm = 1      ! type of thermodynamics
@@ -379,7 +380,7 @@
       subroutine icepack_init_parameters(   &
          puny_in, bignum_in, pi_in, secday_in, &
          rhos_in, rhoi_in, rhow_in, cp_air_in, emissivity_in, &
-         cp_ice_in, cp_ocn_in, &
+         cp_ice_in, cp_ocn_in, hfrazilmin_in, floediam_in, &
          depressT_in, dragio_in, albocn_in, gravit_in, viscosity_dyn_in, &
          Tocnfrz_in, rhofresh_in, zvir_in, vonkar_in, cp_wv_in, &
          stefan_boltzmann_in, ice_ref_salinity_in, &
@@ -441,6 +442,8 @@
 !-----------------------------------------------------------------------
 
       real (kind=dbl_kind), intent(in), optional :: &
+         floediam_in,   & ! effective floe diameter for lateral melt (m)
+         hfrazilmin_in, & ! min thickness of new frazil ice (m)
          cp_ice_in,     & ! specific heat of fresh ice (J/kg/K)
          cp_ocn_in,     & ! specific heat of ocn    (J/kg/K)
          depressT_in,   & ! Tf:brine salinity ratio (C/ppt)
@@ -716,6 +719,8 @@
       if (present(rhow_in)              ) rhow             = rhow_in
       if (present(cp_air_in)            ) cp_air           = cp_air_in
       if (present(emissivity_in)        ) emissivity       = emissivity_in
+      if (present(floediam_in)          ) floediam         = floediam_in
+      if (present(hfrazilmin_in)        ) hfrazilmin       = hfrazilmin_in
       if (present(cp_ice_in)            ) cp_ice           = cp_ice_in
       if (present(cp_ocn_in)            ) cp_ocn           = cp_ocn_in
       if (present(depressT_in)          ) depressT         = depressT_in
@@ -877,7 +882,7 @@
          p2_out, p4_out, p5_out, p6_out, p05_out, p15_out, p25_out, p75_out, &
          p333_out, p666_out, spval_const_out, pih_out, piq_out, pi2_out, &
          rhos_out, rhoi_out, rhow_out, cp_air_out, emissivity_out, &
-         cp_ice_out, cp_ocn_out, &
+         cp_ice_out, cp_ocn_out, hfrazilmin_out, floediam_out, &
          depressT_out, dragio_out, albocn_out, gravit_out, viscosity_dyn_out, &
          Tocnfrz_out, rhofresh_out, zvir_out, vonkar_out, cp_wv_out, &
          stefan_boltzmann_out, ice_ref_salinity_out, &
@@ -948,6 +953,8 @@
 !-----------------------------------------------------------------------
 
       real (kind=dbl_kind), intent(out), optional :: &
+         floediam_out,   & ! effective floe diameter for lateral melt (m)
+         hfrazilmin_out, & ! min thickness of new frazil ice (m)
          cp_ice_out,     & ! specific heat of fresh ice (J/kg/K)
          cp_ocn_out,     & ! specific heat of ocn    (J/kg/K)
          depressT_out,   & ! Tf:brine salinity ratio (C/ppt)
@@ -1264,6 +1271,8 @@
       if (present(rhow_out)              ) rhow_out         = rhow
       if (present(cp_air_out)            ) cp_air_out       = cp_air
       if (present(emissivity_out)        ) emissivity_out   = emissivity
+      if (present(floediam_out)          ) floediam_out     = floediam
+      if (present(hfrazilmin_out)        ) hfrazilmin_out   = hfrazilmin
       if (present(cp_ice_out)            ) cp_ice_out       = cp_ice
       if (present(cp_ocn_out)            ) cp_ocn_out       = cp_ocn
       if (present(depressT_out)          ) depressT_out     = depressT
@@ -1435,6 +1444,8 @@
         write(iounit,*) "  rhow   = ",rhow
         write(iounit,*) "  cp_air = ",cp_air
         write(iounit,*) "  emissivity = ",emissivity
+        write(iounit,*) "  floediam   = ",floediam
+        write(iounit,*) "  hfrazilmin = ",hfrazilmin
         write(iounit,*) "  cp_ice = ",cp_ice
         write(iounit,*) "  cp_ocn = ",cp_ocn
         write(iounit,*) "  depressT = ",depressT

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -281,7 +281,7 @@
          floeshape = 0.666_dbl_kind   ! constant from Steele (unitless)
 
       real (kind=dbl_kind), public :: &
-         floediam  = 300.0_dbl_kind   ,&! effective floe diameter for lateral melt (m)
+         floediam  = 300.0_dbl_kind   ! effective floe diameter for lateral melt (m)
 
       logical (kind=log_kind), public :: &
          wave_spec = .false.          ! if true, use wave forcing

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -96,7 +96,6 @@
 !-----------------------------------------------------------------------
 
       real (kind=dbl_kind), public :: &
-         floediam  = 300.0_dbl_kind   ,&! effective floe diameter for lateral melt (m)
          hfrazilmin = 0.05_dbl_kind   ,&! min thickness of new frazil ice (m)
          cp_ice    = 2106._dbl_kind   ,&! specific heat of fresh ice (J/kg/K)
          cp_ocn    = 4218._dbl_kind   ,&! specific heat of ocn    (J/kg/K)
@@ -280,6 +279,9 @@
 
       real (kind=dbl_kind), public :: &
          floeshape = 0.666_dbl_kind   ! constant from Steele (unitless)
+
+      real (kind=dbl_kind), public :: &
+         floediam  = 300.0_dbl_kind   ,&! effective floe diameter for lateral melt (m)
 
       logical (kind=log_kind), public :: &
          wave_spec = .false.          ! if true, use wave forcing

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -278,7 +278,7 @@
          nfreq = 25                   ! number of frequencies
 
       real (kind=dbl_kind), public :: &
-         floeshape = 0.666_dbl_kind   ! constant from Steele (unitless)
+         floeshape = 0.66_dbl_kind    ! constant from Steele (unitless)
 
       real (kind=dbl_kind), public :: &
          floediam  = 300.0_dbl_kind   ! effective floe diameter for lateral melt (m)

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -26,7 +26,7 @@
       use icepack_parameters, only: phi_init, dsin0_frazil, hs_ssl, salt_loss
       use icepack_parameters, only: rhosi, conserv_check
       use icepack_parameters, only: kitd, ktherm, heat_capacity
-      use icepack_parameters, only: z_tracers, solve_zsal
+      use icepack_parameters, only: z_tracers, solve_zsal, hfrazilmin
 
       use icepack_tracers, only: ntrcr, nbtrcr
       use icepack_tracers, only: nt_qice, nt_qsno, nt_fbri, nt_sice
@@ -47,7 +47,6 @@
       use icepack_itd, only: column_sum, column_conservation_check
       use icepack_isotope, only: isoice_alpha, isotope_frac_method
       use icepack_mushy_physics, only: liquidus_temperature_mush, enthalpy_mush
-      use icepack_therm_shared, only: hfrazilmin
       use icepack_therm_shared, only: hi_min
       use icepack_zbgc, only: add_new_ice_bgc
       use icepack_zbgc, only: lateral_melt_bgc               

--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -47,9 +47,6 @@
       logical (kind=log_kind), public :: &
          l_brine         ! if true, treat brine pocket effects
 
-      real (kind=dbl_kind), parameter, public :: &
-         hfrazilmin = 0.05_dbl_kind ! min thickness of new frazil ice (m)
-
       real (kind=dbl_kind), public :: &
          hi_min          ! minimum ice thickness allowed (m)
 

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -26,7 +26,7 @@
       use icepack_parameters, only: ktherm, heat_capacity, calc_Tsfc
       use icepack_parameters, only: ustar_min, fbot_xfer_type, formdrag, calc_strair
       use icepack_parameters, only: rfracmin, rfracmax, pndaspect, dpscale, frzpnd
-      use icepack_parameters, only: phi_i_mushy, floediam
+      use icepack_parameters, only: phi_i_mushy, floeshape, floediam
 
       use icepack_tracers, only: tr_iage, tr_FY, tr_aero, tr_pond, tr_fsd, tr_iso
       use icepack_tracers, only: tr_pond_cesm, tr_pond_lvl, tr_pond_topo
@@ -556,7 +556,6 @@
       ! Parameters for lateral melting
 
       real (kind=dbl_kind), parameter :: &
-         floeshape = 0.66_dbl_kind , & ! constant from Steele (unitless)
          m1 = 1.6e-6_dbl_kind     , & ! constant from Maykut & Perovich
                                       ! (m/s/deg^(-m2))
          m2 = 1.36_dbl_kind           ! constant from Maykut & Perovich

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -26,7 +26,7 @@
       use icepack_parameters, only: ktherm, heat_capacity, calc_Tsfc
       use icepack_parameters, only: ustar_min, fbot_xfer_type, formdrag, calc_strair
       use icepack_parameters, only: rfracmin, rfracmax, pndaspect, dpscale, frzpnd
-      use icepack_parameters, only: phi_i_mushy
+      use icepack_parameters, only: phi_i_mushy, floediam
 
       use icepack_tracers, only: tr_iage, tr_FY, tr_aero, tr_pond, tr_fsd, tr_iso
       use icepack_tracers, only: tr_pond_cesm, tr_pond_lvl, tr_pond_topo
@@ -556,7 +556,6 @@
       ! Parameters for lateral melting
 
       real (kind=dbl_kind), parameter :: &
-         floediam = 300.0_dbl_kind, & ! effective floe diameter (m)
          floeshape = 0.66_dbl_kind , & ! constant from Steele (unitless)
          m1 = 1.6e-6_dbl_kind     , & ! constant from Maykut & Perovich
                                       ! (m/s/deg^(-m2))

--- a/configuration/driver/icedrv_init.F90
+++ b/configuration/driver/icedrv_init.F90
@@ -88,7 +88,7 @@
          ahmax, R_ice, R_pnd, R_snw, dT_mlt, rsnw_mlt, ksno, &
          mu_rdg, hs0, dpscale, rfracmin, rfracmax, pndaspect, hs1, hp1, &
          a_rapid_mode, Rac_rapid_mode, aspect_rapid_mode, dSdt_slow_mode, &
-         phi_c_slow_mode, phi_i_mushy, kalg, emissivity
+         phi_c_slow_mode, phi_i_mushy, kalg, emissivity, floediam, hfrazilmin
 
       integer (kind=int_kind) :: ktherm, kstrength, krdg_partic, krdg_redist, &
          natmiter, kitd, kcatbound
@@ -135,7 +135,8 @@
         kitd,           ktherm,          ksno,     conduct,             &
         a_rapid_mode,   Rac_rapid_mode,  aspect_rapid_mode,             &
         dSdt_slow_mode, phi_c_slow_mode, phi_i_mushy,                   &
-        sw_redist,      sw_frac,         sw_dtemp
+        sw_redist,      sw_frac,         sw_dtemp,                      &
+        floediam,       hfrazilmin
 
       namelist /dynamics_nml/ &
         kstrength,      krdg_partic,    krdg_redist,    mu_rdg,         &
@@ -198,6 +199,7 @@
            rfracmin_out=rfracmin, rfracmax_out=rfracmax, &
            pndaspect_out=pndaspect, hs1_out=hs1, hp1_out=hp1, &
            ktherm_out=ktherm, calc_Tsfc_out=calc_Tsfc, &
+           floediam_out=floediam, hfrazilmin_out=hfrazilmin, &
            update_ocn_f_out = update_ocn_f, &
            conduct_out=conduct, a_rapid_mode_out=a_rapid_mode, &
            Rac_rapid_mode_out=Rac_rapid_mode, &
@@ -576,6 +578,8 @@
          write(nu_diag,1005) ' atmiter_conv              = ', atmiter_conv
          write(nu_diag,1010) ' calc_strair               = ', calc_strair
          write(nu_diag,1010) ' calc_Tsfc                 = ', calc_Tsfc
+         write(nu_diag,1005) ' floediam                  = ', floediam
+         write(nu_diag,1005) ' hfrazilmin                = ', hfrazilmin
 
          write(nu_diag,*)    ' atm_data_type             = ', &
                                trim(atm_data_type)
@@ -765,6 +769,7 @@
            dpscale_in=dpscale, frzpnd_in=frzpnd, &
            rfracmin_in=rfracmin, rfracmax_in=rfracmax, &
            pndaspect_in=pndaspect, hs1_in=hs1, hp1_in=hp1, &
+           floediam_in=floediam, hfrazilmin_in=hfrazilmin, &
            ktherm_in=ktherm, calc_Tsfc_in=calc_Tsfc, &
            conduct_in=conduct, a_rapid_mode_in=a_rapid_mode, &
            Rac_rapid_mode_in=Rac_rapid_mode, &

--- a/configuration/scripts/icepack_in
+++ b/configuration/scripts/icepack_in
@@ -47,6 +47,8 @@
     sw_redist         = .false.
     sw_frac           = 0.9d0
     sw_dtemp          = 0.02d0
+    floediam          = 300.0d0
+    hfrazilmin        = 0.05d0
 /
 
 &shortwave_nml

--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -742,16 +742,6 @@ url = {https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2019MS001916},
 year = {2020}
 }
 
-@article{Steele92,
-  author = "M. Steele",
-  journal = JGR,
-  number = {C11},
-  pages = {17729},
-  title = {{Sea ice melting and floe geometry in a simple ice-ocean model}},
-  url = {http://doi.wiley.com/10.1029/92JC01755},
-  volume = {97},
-  year = {1992}
-}
 
 
 %  **********************************************

--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -742,6 +742,17 @@ url = {https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2019MS001916},
 year = {2020}
 }
 
+@article{Steele92,
+  author = "M. Steele",
+  journal = JGR,
+  number = {C11},
+  pages = {17729},
+  title = {{Sea ice melting and floe geometry in a simple ice-ocean model}},
+  url = {http://doi.wiley.com/10.1029/92JC01755},
+  volume = {97},
+  year = {1992}
+}
+
 
 %  **********************************************
 %  For new entries, see example entry in BIB_TEMPLATE.txt

--- a/doc/source/user_guide/interfaces.include
+++ b/doc/source/user_guide/interfaces.include
@@ -729,7 +729,7 @@ icepack_init_parameters
         subroutine icepack_init_parameters(   &
            puny_in, bignum_in, pi_in, secday_in, &
            rhos_in, rhoi_in, rhow_in, cp_air_in, emissivity_in, &
-           cp_ice_in, cp_ocn_in, &
+           cp_ice_in, cp_ocn_in, hfrazilmin_in, floediam_in, &
            depressT_in, dragio_in, albocn_in, gravit_in, viscosity_dyn_in, &
            Tocnfrz_in, rhofresh_in, zvir_in, vonkar_in, cp_wv_in, &
            stefan_boltzmann_in, ice_ref_salinity_in, &
@@ -791,6 +791,8 @@ icepack_init_parameters
   !-----------------------------------------------------------------------
   
         real (kind=dbl_kind), intent(in), optional :: &
+           floediam_in,   & ! effective floe diameter (m)
+           hfrazilmin_in, & ! min thickness of new frazil ice (m)
            cp_ice_in,     & ! specific heat of fresh ice (J/kg/K)
            cp_ocn_in,     & ! specific heat of ocn    (J/kg/K)
            depressT_in,   & ! Tf:brine salinity ratio (C/ppt)
@@ -1075,7 +1077,7 @@ icepack_query_parameters
            p2_out, p4_out, p5_out, p6_out, p05_out, p15_out, p25_out, p75_out, &
            p333_out, p666_out, spval_const_out, pih_out, piq_out, pi2_out, &
            rhos_out, rhoi_out, rhow_out, cp_air_out, emissivity_out, &
-           cp_ice_out, cp_ocn_out, &
+           cp_ice_out, cp_ocn_out, hfrazilmin_out, floediam_out, &
            depressT_out, dragio_out, albocn_out, gravit_out, viscosity_dyn_out, &
            Tocnfrz_out, rhofresh_out, zvir_out, vonkar_out, cp_wv_out, &
            stefan_boltzmann_out, ice_ref_salinity_out, &
@@ -1146,6 +1148,8 @@ icepack_query_parameters
   !-----------------------------------------------------------------------
   
         real (kind=dbl_kind), intent(out), optional :: &
+           floediam_out,   & ! effective floe diameter (m)
+           hfrazilmin_out, & ! min thickness of new frazil ice (m)
            cp_ice_out,     & ! specific heat of fresh ice (J/kg/K)
            cp_ocn_out,     & ! specific heat of ocn    (J/kg/K)
            depressT_out,   & ! Tf:brine salinity ratio (C/ppt)

--- a/doc/source/user_guide/interfaces.include
+++ b/doc/source/user_guide/interfaces.include
@@ -791,7 +791,7 @@ icepack_init_parameters
   !-----------------------------------------------------------------------
   
         real (kind=dbl_kind), intent(in), optional :: &
-           floediam_in,   & ! effective floe diameter (m)
+           floediam_in,   & ! effective floe diameter for lateral melt (m)
            hfrazilmin_in, & ! min thickness of new frazil ice (m)
            cp_ice_in,     & ! specific heat of fresh ice (J/kg/K)
            cp_ocn_in,     & ! specific heat of ocn    (J/kg/K)
@@ -1148,7 +1148,7 @@ icepack_query_parameters
   !-----------------------------------------------------------------------
   
         real (kind=dbl_kind), intent(out), optional :: &
-           floediam_out,   & ! effective floe diameter (m)
+           floediam_out,   & ! effective floe diameter for lateral melt (m)
            hfrazilmin_out, & ! min thickness of new frazil ice (m)
            cp_ice_out,     & ! specific heat of fresh ice (J/kg/K)
            cp_ocn_out,     & ! specific heat of ocn    (J/kg/K)

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -199,6 +199,8 @@ thermo_nml
    "``conduct``", "``bubbly``", "conductivity scheme :cite:`Pringle07`", "``bubbly``"
    "", "``MU71``", "conductivity :cite:`Maykut71`", ""
    "``dSdt_slow_mode``", "real", "slow drainage strength parameter m/s/K", "-1.5e-7"
+   "``floediam``", "real", "effective floe diameter for lateral melt in m", "300.0"
+   "``hfrazilmin``", "real", "min thickness of new frazil ice in m", "0.05"
    "``kitd``", "``0``", "delta function ITD approximation", "1"
    "", "``1``", "linear remapping ITD approximation", ""
    "``ksno``", "real", "snow thermal conductivity", "0.3"


### PR DESCRIPTION
 PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Moved floediam and hfrazilmin to icepack parameters
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Tested on cheyenne with 3 compilers.  fsd results are different.  We updated the floeshape value to 0.66 and those test results are
https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#d94b1d60f7e53c42591da3aa73254133083a96d5
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial
            fixed duplicate definition of floeshape and changed working value from 0.666 to 0.66.
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

See https://github.com/CICE-Consortium/CICE/issues/472
Added floediam and hfrazilmin to the thermo namelist in the icepack driver
Settable via a call to icepack_parameters
Defaults left unchanged
Added variables to icepack_in
Removed redundant declaration of floeshape in icepack_therm_vertical.  This resulted in non bit-for-bit results for fsd cases.  effective floeshape was changed from 0.666 to 0.66.