### PR TITLE
zsalinity bug fix

### DIFF
--- a/columnphysics/icepack_zbgc.F90
+++ b/columnphysics/icepack_zbgc.F90
@@ -78,9 +78,9 @@
 
       integer (kind=int_kind), intent(in) :: &
          nblyr   , & ! number of bio layers
-         ncat     , & ! number of thickness categories
-         nilyr    , & ! number of ice layers
-         nltrcr, & ! number of zbgc tracers
+         ncat    , & ! number of thickness categories
+         nilyr   , & ! number of ice layers
+         nltrcr  , & ! number of zbgc tracers
          nbtrcr  , & ! number of biology tracers
          ntrcr       ! number of tracers in use
 
@@ -525,7 +525,7 @@
             do k = 1, nilyr
                trcrn(nt_sice+k-1) = trtmp(nt_sice+k-1)   
             enddo        !k
-         endif   ! solve_zsal
+         endif  ! solve_zsal
 
       endif     ! location
 
@@ -534,7 +534,6 @@
 !=======================================================================
 !autodocument_start icepack_init_bgc
 !
-
       subroutine icepack_init_bgc(ncat, nblyr, nilyr, ntrcr_o, &
          cgrid, igrid, ntrcr, nbtrcr, &
          sicen, trcrn, sss, ocean_bio_all)

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -480,15 +480,6 @@
 
       do i = 1, nx
 
-         do n = 1, ncat
-            do k = 1, nilyr
-               sicen(k,n) = trcrn(i,nt_sice+k-1,n)
-            enddo
-            do k = ntrcr_o+1, ntrcr
-               trcrn_bgc(k-ntrcr_o,n) = trcrn(i,k,n)
-            enddo
-         enddo
-
          call icepack_load_ocean_bio_array(max_nbtrcr=max_nbtrcr,             &
                       max_algae=max_algae, max_don=max_don,  max_doc=max_doc, &
                       max_aero =max_aero,  max_dic=max_dic,  max_fe =max_fe,  &
@@ -504,6 +495,16 @@
       enddo  ! i
 
       do i = 1, nx
+
+         do n = 1, ncat
+            do k = 1, nilyr
+               sicen(k,n) = trcrn(i,nt_sice+k-1,n)
+            enddo
+            do k = ntrcr_o+1, ntrcr
+               trcrn_bgc(k-ntrcr_o,n) = trcrn(i,k,n)
+            enddo
+         enddo
+
          call icepack_init_bgc(ncat=ncat, nblyr=nblyr, nilyr=nilyr, ntrcr_o=ntrcr_o, &
                       cgrid=cgrid, igrid=igrid, ntrcr=ntrcr, nbtrcr=nbtrcr,          &
                       sicen=sicen(:,:), trcrn=trcrn_bgc(:,:),                        &


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
Bug fix: move initialization of the array sicen into the i loop in which it is used.
- [x] Developer(s): 
@eclare108213 
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.

148 measured results of 148 total results
148 of 148 tests PASSED
0 of 148 tests PENDING
0 of 148 tests MISSING data
0 of 148 tests FAILED

https://github.com/CICE-Consortium/Test-Results/wiki/9c33551629.badger.intel.20-12-30.174250.0

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

In icedrv_init_column.F90, the sicen array is set as a slice of the trcrn array for each grid cell, but that was done in a loop prior to the loop in which it is used, so only i=nx values were used.  The changes to icepack_zbgc.F90 are purely cosmetic.

This does not fix the problem in cice ([PR #548](https://github.com/CICE-Consortium/CICE/pull/548)). There is another bug fix for that, independent of these changes ([PR#549](https://github.com/CICE-Consortium/CICE/pull/549)).  