### PR TITLE
modify error tolerance for rare mushy thermo failure

### DIFF
--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -1887,7 +1887,7 @@
            - fsnow*Lfresh - fadvocn) * dt
       ferr = abs(efinal-einit-einp) / dt
 
-      if (ferr > ferrmax) then
+      if (ferr > 1.1_dbl_kind*ferrmax) then
          call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
          call icepack_warnings_add(subname//" conservation_check_vthermo: Thermo energy conservation error" ) 
 


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
This is a bugfix for a very infrequent failure in the mushy layer thermodynamics. The mushy temperature change iteration is currently set to a tolerance of ferrmax which is the same as the final energy conservation tolerance. Every so often, when the temperature change iteration error is very close to ferrmax, the total energy conservation will fail because of round-off level errors in the thickness routine. 
- [x] Developer(s): 
@njeffery @eclare108213 @dabail10 
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
Should not affect any of our tests -- this is expected to be BFB.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit unless the results lie outside of the original error tolerance, which would trigger an abort.
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:
This problem turned up in MPAS-seaice and was addressed there by lowering the error tolerance in ice_therm_mushy.F90 to 0.9*ferrmax, which will likely not be BFB.  Instead, we are loosening the final error tolerance comparison for this rare case, which will not affect any of our tests because they do not hit this problem (they would abort if they did).  This modification will allow the code to run without aborting in this special case.  See https://github.com/CICE-Consortium/Icepack/issues/233.  
