### PR TITLE
Add `.gitattributes` and define diff attribute for Fortran files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.F90	diff=fortran


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    See title
- [X] Developer(s): 
    P Blain
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    No Icepack tests needed.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No (already in CICE)
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [x] Please provide any additional information or relevant details below:

This makes Git aware that files ending in `*.F90` are Fortran source
files, and activates the special regexes included in Git [1] so that
several commands are more useful since they recognize function,
subroutine and module boundaries:

- `git diff` [1], [2]
- `git grep` [3], [4]
- `git log` [5]
- `git blame` [6]

[1] https://git-scm.com/docs/gitattributes#_defining_a_custom_hunk_header
[2] https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--W
[3] https://git-scm.com/docs/git-grep#Documentation/git-grep.txt--p
[4] https://git-scm.com/docs/git-grep#Documentation/git-grep.txt--W
[5] https://git-scm.com/docs/git-log#Documentation/git-log.txt--Lltstartgtltendgtltfilegt
[6] https://git-scm.com/docs/git-blame#Documentation/git-blame.txt--Lltstartgtltendgt

