### PR TITLE
Protect merge of meltsliq when tr_snow is off in merge_fluxes

### DIFF
--- a/columnphysics/icepack_flux.F90
+++ b/columnphysics/icepack_flux.F90
@@ -12,7 +12,7 @@
       use icepack_parameters, only: c1, emissivity
       use icepack_warnings, only: warnstr, icepack_warnings_add
       use icepack_warnings, only: icepack_warnings_setabort, icepack_warnings_aborted
-      use icepack_tracers, only: tr_iso
+      use icepack_tracers, only: tr_iso, tr_snow
 
       implicit none
       private
@@ -217,7 +217,9 @@
       meltt     = meltt     + melttn    * aicen
       meltb     = meltb     + meltbn    * aicen
       melts     = melts     + meltsn    * aicen
-      meltsliq  = meltsliq  + meltsliqn * aicen
+      if (tr_snow) then
+         meltsliq  = meltsliq  + meltsliqn * aicen
+      endif
       dsnow     = dsnow     + dsnown    * aicen
       congel    = congel    + congeln   * aicen
       snoice    = snoice    + snoicen   * aicen


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Avoid computations on uninitialized variable meltsliq in merge_fluxes
- [X] Developer(s): 
    apcraig, DeniseWorthen
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested on cheyenne with intel, results as expected, https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#8da18e20e7a278f8f70f92d50c5d4f7b1b1cc478
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

Fixes a problems that arises in debug mode when initializing data to Nans.  Similar to iso implementation in same routine.