### PR TITLE
Fix two output conversion errors 

### DIFF
--- a/columnphysics/icepack_fsd.F90
+++ b/columnphysics/icepack_fsd.F90
@@ -228,8 +228,8 @@
          floe_rad(n) = floe_rad_h(n)
          ! Save character string to write to history file
          write (c_nf, '(i2)') n    
-         write (c_fsd1, '(f6.3)') floe_rad(n-1)
-         write (c_fsd2, '(f6.3)') floe_rad(n)
+         write (c_fsd1, '(f7.3)') floe_rad(n-1)
+         write (c_fsd2, '(f7.3)') floe_rad(n)
          c_fsd_range(n)=c_fsd1//'m < fsd Cat '//c_nf//' < '//c_fsd2//'m'
       enddo
 

--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -1953,8 +1953,8 @@
             write (c_nc, '(i2)') n    
 
             ! Write hin_max to character string
-            write (c_hinmax1, '(f6.3)') hin_max(n-1)
-            write (c_hinmax2, '(f6.3)') hin_max(n)
+            write (c_hinmax1, '(f7.3)') hin_max(n-1)
+            write (c_hinmax2, '(f7.3)') hin_max(n)
 
             ! Save character string to write to history file
             c_hi_range(n)=c_hinmax1//'m < hi Cat '//c_nc//' < '//c_hinmax2//'m'


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    title
- [x] Developer(s): 
    me
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    Only affects textual model output - I did not run the test suite but can if we feel it's needed.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [x] Yes: a CICE PR to update Icepack will follow once this one is merged
    - [ ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [x] Please provide any additional information or relevant details below:


I stumbled upon this on our new systems, where I have to define `FOR_DUMP_CORE_FILE` in order to get core dumps (which was not necessary on Cray). This, along with the flag `-check` which we use in debug builds, leads to "output conversion error" being fatal instead of just severe (and so the model aborts instead of continuing and writing ****** for the offending write).

Note that we can also add `-check nooutput_conversion` to the compiling flags to completely bypass these errors, but I think it's better to fix them.

Full commit messages follow:

---

5edb20e icepack_fsd: fix format string length causing "output conversion error"

If floe_rad(n) or floe_rad(n-1) is greater or equal to 100, writing it
to c_fsd[12] with the format specifier '(f6.3)' causes an "output
conversion error" when compiling with the Intel compiler, as the format
spec is one digit short. This is not ideal for reasons detailed in the
previous commit.

Bump the format spec by one digit to avoid that error.

91ae9f3 icepack_itd: fix format string length causing "output conversion error"

With kcatbound = -1 (single category run) (or kcatbound = 2), hin_max(n)
is 100 (or 999), which is one character too long for the format
specification '(f6.3)' used to output it in icepack_init_itd_hist. This
leads to an "output conversion error" (Intel Fortran runtime error code
63, [1]), which is usually not fatal.

However, this error becomes fatal if FOR_DUMP_CORE_FILE [2] is defined in
the environment, which is necessary on some platforms to get core dumps
from a crashing program. Note that this interaction is *not* mentioned
in the Intel documentation.

Increase the format specifier by one digit to avoid this error. For
consistency, also increase it for 'hin_max(n-1)'.

[1] https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/compiler-reference/error-handling/handling-run-time-errors/list-of-run-time-error-messages.html
[2] https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/compilation/supported-environment-variables.html#supported-environment-variables_GUID-D3C9AA20-CD90-4833-8B90-AB971E7B90B1

