### PR TITLE
reorder functions frzmlt_bottom_lateral and neutral_coeffs

### DIFF
--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -2624,26 +2624,6 @@
          enddo
       endif
 
-      !-----------------------------------------------------------------
-      ! Adjust frzmlt to account for ice-ocean heat fluxes since last
-      !  call to coupler.
-      ! Compute lateral and bottom heat fluxes.
-      !-----------------------------------------------------------------
-
-      call frzmlt_bottom_lateral (dt,        ncat,      &
-                                  nilyr,     nslyr,     &
-                                  aice,      frzmlt,    &
-                                  vicen,     vsnon,     &
-                                  zqin,      zqsn,      &
-                                  sst,       Tf,        &
-                                  ustar_min,            &
-                                  fbot_xfer_type,       &
-                                  strocnxT,  strocnyT,  &
-                                  Tbot,      fbot,      &
-                                  rside,     Cdn_ocn,   &
-                                  fside)
-
-      if (icepack_warnings_aborted(subname)) return
 
       !-----------------------------------------------------------------
       ! Update the neutral drag coefficients to account for form drag
@@ -2668,6 +2648,27 @@
                                    dfloe       , ncat)
          if (icepack_warnings_aborted(subname)) return
       endif
+
+      !-----------------------------------------------------------------
+      ! Adjust frzmlt to account for ice-ocean heat fluxes since last
+      !  call to coupler.
+      ! Compute lateral and bottom heat fluxes.
+      !-----------------------------------------------------------------
+
+      call frzmlt_bottom_lateral (dt,        ncat,      &
+                                  nilyr,     nslyr,     &
+                                  aice,      frzmlt,    &
+                                  vicen,     vsnon,     &
+                                  zqin,      zqsn,      &
+                                  sst,       Tf,        &
+                                  ustar_min,            &
+                                  fbot_xfer_type,       &
+                                  strocnxT,  strocnyT,  &
+                                  Tbot,      fbot,      &
+                                  rside,     Cdn_ocn,   &
+                                  fside)
+
+      if (icepack_warnings_aborted(subname)) return
 
       do n = 1, ncat
          meltsn (n) = c0


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    reorder functions frzmlt_bottom_lateral and neutral_coeffsder to update CDN_ocn before it is used.
This only changes results when formdrag is applied and fbot_xfer_type) == 'Cdn_ocn'.
- [ x] Developer(s): 
    @TillRasmussen 
- [ ] Suggest PR reviewers from list in the column to the right.
 @eclare108213 @apcraig @phil-blain 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
 Not bit for bit when formdrag and Cdn_ocn are set. Otherwize bit for bit 
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [x ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [ x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x ] No 
- [ ] Please provide any additional information or relevant details below:
Replaces #380 cleaned up