### PR TITLE
Add support for disabling thermodynamics

### DIFF
--- a/configuration/driver/icedrv_RunMod.F90
+++ b/configuration/driver/icedrv_RunMod.F90
@@ -102,6 +102,7 @@
       use icedrv_flux, only: init_history_therm, init_history_bgc, &
           daidtt, daidtd, dvidtt, dvidtd, dagedtt, dagedtd, init_history_dyn
       use icedrv_history, only: history_cdf, history_write
+      use icepack_parameters, only: ktherm
       use icedrv_restart, only: dumpfile, final_restart
       use icedrv_restart_bgc, only: write_restart_bgc
       use icedrv_step, only: prep_radiation, step_therm1, step_therm2, &
@@ -148,7 +149,7 @@
       ! Scale radiation fields
       !-----------------------------------------------------------------
       
-      if (calc_Tsfc) call prep_radiation ()
+      if (calc_Tsfc .and. ktherm >= 0) call prep_radiation ()
 
 !      call icedrv_diagnostics_debug ('post prep_radiation')
 
@@ -157,8 +158,10 @@
       !-----------------------------------------------------------------
 
       call step_therm1     (dt) ! vertical thermodynamics
-      call biogeochemistry (dt) ! biogeochemistry
-      call step_therm2     (dt) ! ice thickness distribution thermo
+      if (ktherm >= 0) then
+         call biogeochemistry (dt) ! biogeochemistry
+         call step_therm2     (dt) ! ice thickness distribution thermo
+      endif
 
       ! clean up, update tendency diagnostics
       offset = dt
@@ -204,7 +207,8 @@
       ! albedo, shortwave radiation
       !-----------------------------------------------------------------
       
-      call step_radiation (dt)
+      if (ktherm >= 0) &
+         call step_radiation (dt)
 
       !-----------------------------------------------------------------
       ! get ready for coupling and the next time step


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    @phil-blain 
- [X] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    - ran a test case with the default settings, it completed successfully
    - ran a test case with `ktherm=-1` modified in the namelist, it completed successfully
    - used these modifications in CICE+NEMO over the last months to debug my runs
    - we (ECCC) used equivalent modifications in our in-house CICE4/5 for several years to debug our runs.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit (when not using `ktherm=-1`)
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [x] Yes: **the CICE drivers need to be updated with the same logic (always running `step_therm1`)**
    - [ ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No **should I add one ? maybe create `set_nml.nothermo` ?**
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No **`ktherm=-1` is already documented**
- [X] Please provide any additional information or relevant details below:

See commits messages.

This MR is best viewed with ["hide whitespace changes"](https://github.com/CICE-Consortium/Icepack/pull/389/files?diff=split&w=1) since I adjusted the indentation.