### PR TITLE
Deprecate CESM pond option

### DIFF
--- a/columnphysics/icepack_meltpond_cesm.F90
+++ b/columnphysics/icepack_meltpond_cesm.F90
@@ -14,6 +14,7 @@
 
       module icepack_meltpond_cesm
 
+#ifdef UNDEPRECATE_CESMPONDS
       use icepack_kinds
       use icepack_parameters, only: c0, c1, c2, p01, puny
       use icepack_parameters, only: rhofresh, rhoi, rhos, Timelt, pndaspect, use_smliq_pnd
@@ -148,6 +149,7 @@
 
       end subroutine compute_ponds_cesm
 
+#endif
 !=======================================================================
 
       end module icepack_meltpond_cesm

--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -50,7 +50,11 @@
       use icepack_parameters, only: r_ice, r_pnd, r_snw, dt_mlt, rsnw_mlt, hs0, hs1, hp1
       use icepack_parameters, only: pndaspect, albedo_type, albicev, albicei, albsnowv, albsnowi, ahmax
       use icepack_tracers,    only: ntrcr, nbtrcr_sw
+#ifdef UNDEPRECATE_CESMPONDS
       use icepack_tracers,    only: tr_pond_cesm, tr_pond_lvl, tr_pond_topo
+#else
+      use icepack_tracers,    only: tr_pond_lvl, tr_pond_topo
+#endif
       use icepack_tracers,    only: tr_bgc_N, tr_aero
       use icepack_tracers,    only: nt_bgc_N, nt_zaero, tr_bgc_N
       use icepack_tracers,    only: tr_zaero, nlt_chl_sw, nlt_zaero_sw
@@ -1011,6 +1015,7 @@
             if (icepack_warnings_aborted(subname)) return
 
             ! set pond properties
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm) then
                ! fraction of ice area
                fpn = apndn(n)
@@ -1027,6 +1032,9 @@
                fsn = min(fsn, c1-fpn)
                apeffn(n) = fpn ! for history
             elseif (tr_pond_lvl) then
+#else
+            if (tr_pond_lvl) then
+#endif
                hsnlvl = hsn ! initialize
                if (trim(snwredist) == 'bulk') then
                   hsnlvl = hsn / (c1 + snwlvlfac*(c1-alvln(n)))

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -33,7 +33,11 @@
       use icepack_tracers, only: nt_apnd, nt_hpnd, nt_aero, nt_isosno, nt_isoice
       use icepack_tracers, only: nt_Tsfc, nt_iage, nt_FY, nt_fsd, nt_rhos
       use icepack_tracers, only: nt_alvl, nt_vlvl
+#ifdef UNDEPRECATE_CESMPONDS
       use icepack_tracers, only: tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_snow
+#else
+      use icepack_tracers, only: tr_pond_lvl, tr_pond_topo, tr_snow
+#endif
       use icepack_tracers, only: tr_iage, tr_FY, tr_lvl, tr_aero, tr_iso, tr_brine, tr_fsd
       use icepack_tracers, only: n_aero, n_iso
       use icepack_tracers, only: bio_index
@@ -1870,7 +1874,11 @@
                (trcrn(nt_vlvl,n)*vice1 + vin0new(n))/vicen(n)
             endif
 
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm .or. tr_pond_topo) then
+#else
+            if (tr_pond_topo) then
+#endif
                trcrn(nt_apnd,n) = &
                trcrn(nt_apnd,n)*area1/aicen(n)
             elseif (tr_pond_lvl) then

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -29,7 +29,11 @@
       use icepack_parameters, only: phi_i_mushy, floeshape, floediam, use_smliq_pnd, snwredist
 
       use icepack_tracers, only: tr_iage, tr_FY, tr_aero, tr_pond, tr_fsd, tr_iso
+#ifdef UNDEPRECATE_CESMPONDS
       use icepack_tracers, only: tr_pond_cesm, tr_pond_lvl, tr_pond_topo
+#else
+      use icepack_tracers, only: tr_pond_lvl, tr_pond_topo
+#endif
       use icepack_tracers, only: n_aero, n_iso
 
       use icepack_therm_shared, only: ferrmax, l_brine
@@ -53,7 +57,9 @@
       use icepack_age, only: increment_age
       use icepack_firstyear, only: update_FYarea
       use icepack_flux, only: set_sfcflux, merge_fluxes
+#ifdef UNDEPRECATE_CESMPONDS
       use icepack_meltpond_cesm, only: compute_ponds_cesm
+#endif
       use icepack_meltpond_lvl, only: compute_ponds_lvl
       use icepack_meltpond_topo, only: compute_ponds_topo
       use icepack_snow, only: drain_snow
@@ -2867,7 +2873,9 @@
 
       !-----------------------------------------------------------------
       ! Melt ponds
+#ifdef UNDEPRECATE_CESMPONDS
       ! If using tr_pond_cesm, the full calculation is performed here.
+#endif
       ! If using tr_pond_topo, the rest of the calculation is done after
       ! the surface fluxes are merged, below.
       !-----------------------------------------------------------------
@@ -2875,6 +2883,7 @@
          !call ice_timer_start(timer_ponds)
          if (tr_pond) then
                
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm) then
                rfrac = rfracmin + (rfracmax-rfracmin) * aicen(n) 
                call compute_ponds_cesm(dt=dt,           &
@@ -2892,6 +2901,9 @@
                if (icepack_warnings_aborted(subname)) return
                   
             elseif (tr_pond_lvl) then
+#else
+            if (tr_pond_lvl) then
+#endif
                rfrac = rfracmin + (rfracmax-rfracmin) * aicen(n)
                call compute_ponds_lvl (dt=dt,            &
                                        nilyr=nilyr,      &

--- a/columnphysics/icepack_tracers.F90
+++ b/columnphysics/icepack_tracers.F90
@@ -103,7 +103,9 @@
          tr_FY        = .false., & ! if .true., use first-year area tracer
          tr_lvl       = .false., & ! if .true., use level ice tracer
          tr_pond      = .false., & ! if .true., use melt pond tracer
+#ifdef UNDEPRECATE_CESMPONDS
          tr_pond_cesm = .false., & ! if .true., use cesm pond tracer
+#endif
          tr_pond_lvl  = .false., & ! if .true., use level-ice pond tracer
          tr_pond_topo = .false., & ! if .true., use explicit topography-based ponds
          tr_snow      = .false., & ! if .true., use snow metamorphosis tracers
@@ -207,7 +209,11 @@
 
       subroutine icepack_init_tracer_flags(&
            tr_iage_in, tr_FY_in, tr_lvl_in, tr_snow_in, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_pond_in, tr_pond_cesm_in, tr_pond_lvl_in, tr_pond_topo_in, &
+#else
+           tr_pond_in, tr_pond_lvl_in, tr_pond_topo_in, &
+#endif
            tr_fsd_in, tr_aero_in, tr_iso_in, tr_brine_in, tr_zaero_in, &
            tr_bgc_Nit_in, tr_bgc_N_in, tr_bgc_DON_in, tr_bgc_C_in, tr_bgc_chl_in, &
            tr_bgc_Am_in, tr_bgc_Sil_in, tr_bgc_DMS_in, tr_bgc_Fe_in, tr_bgc_hum_in, &
@@ -218,7 +224,9 @@
              tr_FY_in        , & ! if .true., use first-year area tracer
              tr_lvl_in       , & ! if .true., use level ice tracer
              tr_pond_in      , & ! if .true., use melt pond tracer
+#ifdef UNDEPRECATE_CESMPONDS
              tr_pond_cesm_in , & ! if .true., use cesm pond tracer
+#endif
              tr_pond_lvl_in  , & ! if .true., use level-ice pond tracer
              tr_pond_topo_in , & ! if .true., use explicit topography-based ponds
              tr_snow_in      , & ! if .true., use snow metamorphosis tracers
@@ -247,7 +255,9 @@
         if (present(tr_FY_in)  ) tr_FY   = tr_FY_in
         if (present(tr_lvl_in) ) tr_lvl  = tr_lvl_in
         if (present(tr_pond_in)) tr_pond = tr_pond_in
+#ifdef UNDEPRECATE_CESMPONDS
         if (present(tr_pond_cesm_in)) tr_pond_cesm = tr_pond_cesm_in
+#endif
         if (present(tr_pond_lvl_in) ) tr_pond_lvl  = tr_pond_lvl_in
         if (present(tr_pond_topo_in)) tr_pond_topo = tr_pond_topo_in
         if (present(tr_snow_in)   ) tr_snow    = tr_snow_in
@@ -276,7 +286,11 @@
 
       subroutine icepack_query_tracer_flags(&
            tr_iage_out, tr_FY_out, tr_lvl_out, tr_snow_out, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_pond_out, tr_pond_cesm_out, tr_pond_lvl_out, tr_pond_topo_out, &
+#else
+           tr_pond_out, tr_pond_lvl_out, tr_pond_topo_out, &
+#endif
            tr_fsd_out, tr_aero_out, tr_iso_out, tr_brine_out, tr_zaero_out, &
            tr_bgc_Nit_out, tr_bgc_N_out, tr_bgc_DON_out, tr_bgc_C_out, tr_bgc_chl_out, &
            tr_bgc_Am_out, tr_bgc_Sil_out, tr_bgc_DMS_out, tr_bgc_Fe_out, tr_bgc_hum_out, &
@@ -287,7 +301,9 @@
              tr_FY_out        , & ! if .true., use first-year area tracer
              tr_lvl_out       , & ! if .true., use level ice tracer
              tr_pond_out      , & ! if .true., use melt pond tracer
+#ifdef UNDEPRECATE_CESMPONDS
              tr_pond_cesm_out , & ! if .true., use cesm pond tracer
+#endif
              tr_pond_lvl_out  , & ! if .true., use level-ice pond tracer
              tr_pond_topo_out , & ! if .true., use explicit topography-based ponds
              tr_snow_out      , & ! if .true., use snow metamorphosis tracers
@@ -316,7 +332,9 @@
         if (present(tr_FY_out)  ) tr_FY_out   = tr_FY
         if (present(tr_lvl_out) ) tr_lvl_out  = tr_lvl
         if (present(tr_pond_out)) tr_pond_out = tr_pond
+#ifdef UNDEPRECATE_CESMPONDS
         if (present(tr_pond_cesm_out)) tr_pond_cesm_out = tr_pond_cesm
+#endif
         if (present(tr_pond_lvl_out) ) tr_pond_lvl_out  = tr_pond_lvl
         if (present(tr_pond_topo_out)) tr_pond_topo_out = tr_pond_topo
         if (present(tr_snow_out)   ) tr_snow_out    = tr_snow
@@ -356,7 +374,9 @@
         write(iounit,*) "  tr_FY   = ",tr_FY  
         write(iounit,*) "  tr_lvl  = ",tr_lvl 
         write(iounit,*) "  tr_pond = ",tr_pond
+#ifdef UNDEPRECATE_CESMPONDS
         write(iounit,*) "  tr_pond_cesm = ",tr_pond_cesm
+#endif
         write(iounit,*) "  tr_pond_lvl  = ",tr_pond_lvl 
         write(iounit,*) "  tr_pond_topo = ",tr_pond_topo
         write(iounit,*) "  tr_snow    = ",tr_snow

--- a/configuration/driver/icedrv_init.F90
+++ b/configuration/driver/icedrv_init.F90
@@ -111,13 +111,21 @@
       integer (kind=int_kind) :: ntrcr
       logical (kind=log_kind) :: tr_iage, tr_FY, tr_lvl, tr_pond, tr_snow
       logical (kind=log_kind) :: tr_iso, tr_aero, tr_fsd
+#ifdef UNDEPRECATE_CESMPONDS
       logical (kind=log_kind) :: tr_pond_cesm, tr_pond_lvl, tr_pond_topo, wave_spec
+#else
+      logical (kind=log_kind) :: tr_pond_lvl, tr_pond_topo, wave_spec
+#endif
       integer (kind=int_kind) :: nt_Tsfc, nt_sice, nt_qice, nt_qsno, nt_iage, nt_FY
       integer (kind=int_kind) :: nt_alvl, nt_vlvl, nt_apnd, nt_hpnd, nt_ipnd, &
                                  nt_smice, nt_smliq, nt_rhos, nt_rsnw, &
                                  nt_aero, nt_fsd, nt_isosno, nt_isoice
-
+ 
+#ifdef UNDEPRECATE_CESMPONDS
       real (kind=real_kind) :: rpcesm, rplvl, rptopo 
+#else
+      real (kind=real_kind) :: rplvl, rptopo 
+#endif
       real (kind=dbl_kind) :: Cf, puny
 
       character(len=*), parameter :: subname='(input_data)'
@@ -180,7 +188,9 @@
         tr_iage,      &
         tr_FY,        &
         tr_lvl,       &
+#ifdef UNDEPRECATE_CESMPONDS
         tr_pond_cesm, &
+#endif
         tr_pond_lvl,  &
         tr_pond_topo, &
         tr_snow,      &
@@ -281,7 +291,9 @@
       tr_iage      = .false. ! ice age
       tr_FY        = .false. ! ice age
       tr_lvl       = .false. ! level ice 
+#ifdef UNDEPRECATE_CESMPONDS
       tr_pond_cesm = .false. ! CESM melt ponds
+#endif
       tr_pond_lvl  = .false. ! level-ice melt ponds
       tr_pond_topo = .false. ! topographic melt ponds
       tr_snow      = .false. ! snow tracers (wind redistribution, metamorphosis)
@@ -463,17 +475,29 @@
          kcatbound = 0
       endif
 
+#ifdef UNDEPRECATE_CESMPONDS
       rpcesm = c0
+#endif
       rplvl  = c0
       rptopo = c0
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm) rpcesm = c1
+#endif
       if (tr_pond_lvl ) rplvl  = c1
       if (tr_pond_topo) rptopo = c1
 
       tr_pond = .false. ! explicit melt ponds
+#ifdef UNDEPRECATE_CESMPONDS
       if (rpcesm + rplvl + rptopo > puny) tr_pond = .true.
+#else
+      if (rplvl + rptopo > puny) tr_pond = .true.
+#endif
 
+#ifdef UNDEPRECATE_CESMPONDS
       if (rpcesm + rplvl + rptopo > c1 + puny) then
+#else
+      if (rplvl + rptopo > c1 + puny) then
+#endif
          write (nu_diag,*) 'WARNING: Must use only one melt pond scheme'
          call icedrv_system_abort(file=__FILE__,line=__LINE__)
       endif
@@ -490,11 +514,13 @@
          hs0 = c0
       endif
 
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm .and. trim(frzpnd) /= 'cesm') then
          write (nu_diag,*) 'WARNING: tr_pond_cesm=T'
          write (nu_diag,*) 'WARNING: frzpnd, dpscale not used'
          frzpnd = 'cesm'
       endif
+#endif
 
       if (trim(shortwave) /= 'dEdd' .and. tr_pond .and. calc_tsfc) then
          write (nu_diag,*) 'WARNING: Must use dEdd shortwave'
@@ -596,10 +622,12 @@
          calc_strair = .true.
       endif
 
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm) then
          write (nu_diag,*) 'ERROR: formdrag=T but frzpnd=cesm' 
          call icedrv_system_abort(file=__FILE__,line=__LINE__)
       endif
+#endif
 
       if (.not. tr_lvl) then
          write (nu_diag,*) 'WARNING: formdrag=T but tr_lvl=F'
@@ -775,7 +803,9 @@
          write(nu_diag,1010) ' tr_iage                   = ', tr_iage
          write(nu_diag,1010) ' tr_FY                     = ', tr_FY
          write(nu_diag,1010) ' tr_lvl                    = ', tr_lvl
+#ifdef UNDEPRECATE_CESMPONDS
          write(nu_diag,1010) ' tr_pond_cesm              = ', tr_pond_cesm
+#endif
          write(nu_diag,1010) ' tr_pond_lvl               = ', tr_pond_lvl
          write(nu_diag,1010) ' tr_pond_topo              = ', tr_pond_topo
          write(nu_diag,1010) ' tr_snow                   = ', tr_snow
@@ -964,7 +994,11 @@
       call icepack_init_tracer_flags(tr_iage_in=tr_iage, &
            tr_FY_in=tr_FY, tr_lvl_in=tr_lvl, tr_aero_in=tr_aero, &
            tr_iso_in=tr_iso, tr_snow_in=tr_snow, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_pond_in=tr_pond, tr_pond_cesm_in=tr_pond_cesm, &
+#else
+           tr_pond_in=tr_pond, &
+#endif
            tr_pond_lvl_in=tr_pond_lvl, &
            tr_pond_topo_in=tr_pond_topo, tr_fsd_in=tr_fsd)
       call icepack_init_tracer_indices(nt_Tsfc_in=nt_Tsfc, &
@@ -1059,7 +1093,11 @@
 
       integer (kind=int_kind) :: ntrcr
       logical (kind=log_kind) :: tr_iage, tr_FY, tr_lvl, tr_aero, tr_fsd, tr_iso
+#ifdef UNDEPRECATE_CESMPONDS
       logical (kind=log_kind) :: tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_snow
+#else
+      logical (kind=log_kind) :: tr_pond_lvl, tr_pond_topo, tr_snow
+#endif
       integer (kind=int_kind) :: nt_Tsfc, nt_sice, nt_qice, nt_qsno, nt_iage, nt_fy
       integer (kind=int_kind) :: nt_alvl, nt_vlvl, nt_apnd, nt_hpnd, nt_ipnd, &
                                  nt_smice, nt_smliq, nt_rhos, nt_rsnw, &
@@ -1076,7 +1114,11 @@
          call icepack_query_tracer_flags(tr_iage_out=tr_iage, &
               tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, tr_aero_out=tr_aero, &
               tr_iso_out=tr_iso, tr_snow_out=tr_snow, &
+#ifdef UNDEPRECATE_CESMPONDS
               tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+              tr_pond_lvl_out=tr_pond_lvl, &
+#endif
               tr_pond_topo_out=tr_pond_topo, tr_fsd_out=tr_fsd)
          call icepack_query_tracer_indices(nt_Tsfc_out=nt_Tsfc, &
               nt_sice_out=nt_sice, nt_qice_out=nt_qice, &
@@ -1143,10 +1185,12 @@
       if (tr_FY)   trcr_depend(nt_FY)    = 0   ! area-weighted first-year ice area
       if (tr_lvl)  trcr_depend(nt_alvl)  = 0   ! level ice area
       if (tr_lvl)  trcr_depend(nt_vlvl)  = 1   ! level ice volume
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm) then
                    trcr_depend(nt_apnd)  = 0           ! melt pond area
                    trcr_depend(nt_hpnd)  = 2+nt_apnd   ! melt pond depth
       endif
+#endif
       if (tr_pond_lvl) then
                    trcr_depend(nt_apnd)  = 2+nt_alvl   ! melt pond area
                    trcr_depend(nt_hpnd)  = 2+nt_apnd   ! melt pond depth
@@ -1206,10 +1250,12 @@
          nt_strata   (it,2) = 0
       enddo
 
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm) then
          n_trcr_strata(nt_hpnd)   = 1       ! melt pond depth
          nt_strata    (nt_hpnd,1) = nt_apnd ! on melt pond area
       endif
+#endif
       if (tr_pond_lvl) then
          n_trcr_strata(nt_apnd)   = 1       ! melt pond area
          nt_strata    (nt_apnd,1) = nt_alvl ! on level ice area

--- a/configuration/driver/icedrv_restart.F90
+++ b/configuration/driver/icedrv_restart.F90
@@ -20,7 +20,9 @@
           write_restart_age,       read_restart_age, &
           write_restart_FY,        read_restart_FY, &  
           write_restart_lvl,       read_restart_lvl, & 
+#ifdef UNDEPRECATE_CESMPONDS
           write_restart_pond_cesm, read_restart_pond_cesm, & 
+#endif
           write_restart_pond_lvl,  read_restart_pond_lvl, &
           write_restart_pond_topo, read_restart_pond_topo, &
           write_restart_snow,      read_restart_snow, &
@@ -65,7 +67,11 @@
 
       logical (kind=log_kind) :: &
          tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, tr_brine, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_pond_topo, tr_pond_cesm, tr_pond_lvl, tr_snow, tr_fsd
+#else
+         tr_pond_topo, tr_pond_lvl, tr_snow, tr_fsd
+#endif
 !         solve_zsal, skl_bgc, z_tracers
 
       character(len=char_len_long) :: filename
@@ -84,7 +90,11 @@
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
            tr_lvl_out=tr_lvl, tr_aero_out=tr_aero, tr_iso_out=tr_iso, &
            tr_brine_out=tr_brine, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_pond_topo_out=tr_pond_topo, tr_pond_cesm_out=tr_pond_cesm, &
+#else
+           tr_pond_topo_out=tr_pond_topo, &
+#endif
            tr_pond_lvl_out=tr_pond_lvl,tr_snow_out=tr_snow,tr_fsd_out=tr_fsd)
 !      call icepack_query_parameters(solve_zsal_out=solve_zsal, &
 !         skl_bgc_out=skl_bgc, z_tracers_out=z_tracers)
@@ -137,7 +147,9 @@
       if (tr_iage)      call write_restart_age()       ! ice age tracer
       if (tr_FY)        call write_restart_FY()        ! first-year area tracer
       if (tr_lvl)       call write_restart_lvl()       ! level ice tracer
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm) call write_restart_pond_cesm() ! CESM melt ponds
+#endif
       if (tr_pond_lvl)  call write_restart_pond_lvl()  ! level-ice melt ponds
       if (tr_pond_topo) call write_restart_pond_topo() ! topographic melt ponds
       if (tr_snow)      call write_restart_snow()      ! snow metamorphosis tracers
@@ -182,7 +194,11 @@
 
       logical (kind=log_kind) :: &
          tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, tr_brine, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_pond_topo, tr_pond_cesm, tr_pond_lvl, tr_snow, tr_fsd
+#else
+         tr_pond_topo, tr_pond_lvl, tr_snow, tr_fsd
+#endif
 
       character(len=char_len_long) :: filename
       character(len=*), parameter :: subname='(restartfile)'
@@ -204,7 +220,11 @@
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
            tr_lvl_out=tr_lvl, tr_aero_out=tr_aero, tr_iso_out=tr_iso, &
            tr_brine_out=tr_brine, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_pond_topo_out=tr_pond_topo, tr_pond_cesm_out=tr_pond_cesm, &
+#else
+           tr_pond_topo_out=tr_pond_topo, &
+#endif
            tr_pond_lvl_out=tr_pond_lvl,tr_snow_out=tr_snow,tr_fsd_out=tr_fsd)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call icedrv_system_abort(string=subname, &
@@ -265,7 +285,9 @@
       if (tr_iage)      call read_restart_age()       ! ice age tracer
       if (tr_FY)        call read_restart_FY()        ! first-year area tracer
       if (tr_lvl)       call read_restart_lvl()       ! level ice tracer
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm) call read_restart_pond_cesm() ! CESM melt ponds
+#endif
       if (tr_pond_lvl)  call read_restart_pond_lvl()  ! level-ice melt ponds
       if (tr_pond_topo) call read_restart_pond_topo() ! topographic melt ponds
       if (tr_snow)      call read_restart_snow()      ! snow metamorphosis tracers
@@ -716,6 +738,7 @@
 
       end subroutine read_restart_lvl
 
+#ifdef UNDEPRECATE_CESMPONDS
 !=======================================================================!
 
 ! Dumps all values needed for restarting
@@ -765,7 +788,7 @@
       call read_restart_field(nu_restart,trcrn(:,nt_hpnd,:),ncat)
 
       end subroutine read_restart_pond_cesm
-
+#endif
 !=======================================================================
 !
 ! Dumps all values needed for restarting

--- a/configuration/scripts/icepack_in
+++ b/configuration/scripts/icepack_in
@@ -26,7 +26,6 @@
     tr_iage      = .false.
     tr_FY        = .false.
     tr_lvl       = .true.
-    tr_pond_cesm = .false.
     tr_pond_topo = .false.
     tr_pond_lvl  = .true.
     tr_snow      = .false.

--- a/configuration/scripts/options/set_nml.alt01
+++ b/configuration/scripts/options/set_nml.alt01
@@ -10,6 +10,5 @@ atm_data_type = 'default'
 ocn_data_type = 'default'
 formdrag = .true.
 tr_lvl = .false.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .false.

--- a/configuration/scripts/options/set_nml.alt02
+++ b/configuration/scripts/options/set_nml.alt02
@@ -2,7 +2,6 @@
     kitd         = 0
     tr_pond_lvl  = .false.
     tr_pond_topo = .false.
-    tr_pond_cesm = .false.
     ktherm            = 0
     tfrz_option       = 'linear_salt'
     conduct           = 'bubbly'

--- a/configuration/scripts/options/set_nml.alt03
+++ b/configuration/scripts/options/set_nml.alt03
@@ -1,7 +1,6 @@
     kcatbound    = 2
     tr_pond_lvl  = .false.
     tr_pond_topo = .true.
-    tr_pond_cesm = .false.
     ktherm            = 1
     sw_redist         = .true.
     sw_frac           = 0.9d0

--- a/configuration/scripts/options/set_nml.alt04
+++ b/configuration/scripts/options/set_nml.alt04
@@ -3,7 +3,6 @@
     kcatbound    = 3
     tr_pond_lvl  = .true.
     tr_pond_topo = .false.
-    tr_pond_cesm = .false.
     frzpnd          = 'cesm'
     ktherm            = 1
     sw_redist         = .true.

--- a/configuration/scripts/options/set_nml.pondlvl
+++ b/configuration/scripts/options/set_nml.pondlvl
@@ -1,7 +1,6 @@
 tr_iage      = .true.
 tr_FY        = .true.
 tr_lvl       = .true.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .true.
 tr_aero      = .false.

--- a/configuration/scripts/options/set_nml.pondtopo
+++ b/configuration/scripts/options/set_nml.pondtopo
@@ -1,7 +1,6 @@
 tr_iage      = .false.
 tr_FY        = .false.
 tr_lvl       = .false.
-tr_pond_cesm = .false.
 tr_pond_topo = .true.
 tr_pond_lvl  = .false.
 tr_aero      = .false.

--- a/configuration/scripts/options/set_nml.swccsm3
+++ b/configuration/scripts/options/set_nml.swccsm3
@@ -1,6 +1,5 @@
 shortwave       = 'ccsm3'
 albedo_type     = 'ccsm3'
 calc_tsfc       = .true.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .false.

--- a/configuration/scripts/options/set_nml.swredist
+++ b/configuration/scripts/options/set_nml.swredist
@@ -1,6 +1,5 @@
     tr_pond_lvl  = .true.
     tr_pond_topo = .false.
-    tr_pond_cesm = .false.
     ktherm            = 2
     sw_redist         = .true.
     sw_frac           = 0.9d0

--- a/configuration/scripts/tests/base_suite.ts
+++ b/configuration/scripts/tests/base_suite.ts
@@ -21,7 +21,6 @@ smoke          col     1x1        debug,run1year,snwITDrdg
 smoke          col     1x1        debug,run1year,calcdragio
 restart        col     1x1        debug
 restart        col     1x1        diag1
-restart        col     1x1        pondcesm
 restart        col     1x1        pondlvl
 restart        col     1x1        pondtopo
 restart        col     1x1        bgcISPOL

--- a/configuration/scripts/tests/travis_suite.ts
+++ b/configuration/scripts/tests/travis_suite.ts
@@ -11,7 +11,6 @@ smoke          col     1x1        debug,run1year,leap,dt30min
 smoke          col     1x1        debug,run1year,dyn
 restart        col     1x1        debug
 restart        col     1x1        diag1
-restart        col     1x1        pondcesm
 restart        col     1x1        pondlvl
 restart        col     1x1        pondtopo
 restart        col     1x1        bgcISPOL

--- a/doc/source/icepack_index.rst
+++ b/doc/source/icepack_index.rst
@@ -476,7 +476,7 @@ either Celsius or Kelvin units).
    "tr_lvl", ":math:`\bullet` if true, use level ice area and volume tracers", ""
 
 .. comment We are deprecating this feature.
-   "tr_pond_cesm", ":math:`\bullet` if true, use CESM melt pond scheme", ""
+.. "tr_pond_cesm", ":math:`\bullet` if true, use CESM melt pond scheme", ""
 
    "tr_pond_cesm", "DEPRECATED", ""
    "tr_pond_lvl", ":math:`\bullet` if true, use level-ice melt pond scheme", ""

--- a/doc/source/icepack_index.rst
+++ b/doc/source/icepack_index.rst
@@ -474,7 +474,11 @@ either Celsius or Kelvin units).
    "tr_FY", ":math:`\bullet` if true, use first-year area tracer", ""
    "tr_iage", ":math:`\bullet` if true, use ice age tracer", ""
    "tr_lvl", ":math:`\bullet` if true, use level ice area and volume tracers", ""
+
+.. comment We are deprecating this feature.
    "tr_pond_cesm", ":math:`\bullet` if true, use CESM melt pond scheme", ""
+
+   "tr_pond_cesm", "DEPRECATED", ""
    "tr_pond_lvl", ":math:`\bullet` if true, use level-ice melt pond scheme", ""
    "tr_pond_topo", ":math:`\bullet` if true, use topo melt pond scheme", ""
    "trcr", "ice tracers", ""

--- a/doc/source/icepack_index.rst
+++ b/doc/source/icepack_index.rst
@@ -475,8 +475,9 @@ either Celsius or Kelvin units).
    "tr_iage", ":math:`\bullet` if true, use ice age tracer", ""
    "tr_lvl", ":math:`\bullet` if true, use level ice area and volume tracers", ""
 
-.. comment We are deprecating this feature.
-.. "tr_pond_cesm", ":math:`\bullet` if true, use CESM melt pond scheme", ""
+.. 
+   comment We are deprecating this feature.
+   "tr_pond_cesm", ":math:`\bullet` if true, use CESM melt pond scheme", ""
 
    "tr_pond_cesm", "DEPRECATED", ""
    "tr_pond_lvl", ":math:`\bullet` if true, use level-ice melt pond scheme", ""

--- a/doc/source/icepack_index.rst
+++ b/doc/source/icepack_index.rst
@@ -474,11 +474,6 @@ either Celsius or Kelvin units).
    "tr_FY", ":math:`\bullet` if true, use first-year area tracer", ""
    "tr_iage", ":math:`\bullet` if true, use ice age tracer", ""
    "tr_lvl", ":math:`\bullet` if true, use level ice area and volume tracers", ""
-
-.. 
-   comment We are deprecating this feature.
-   "tr_pond_cesm", ":math:`\bullet` if true, use CESM melt pond scheme", ""
-
    "tr_pond_cesm", "DEPRECATED", ""
    "tr_pond_lvl", ":math:`\bullet` if true, use level-ice melt pond scheme", ""
    "tr_pond_topo", ":math:`\bullet` if true, use topo melt pond scheme", ""
@@ -529,3 +524,7 @@ either Celsius or Kelvin units).
    "zref", "reference height for stability", "10. m"
    "zTrf", "reference height for :math:`T_{ref}`, :math:`Q_{ref}`, :math:`U_{ref}`", "2. m"
    "zvir", "gas constant (water vapor)/gas constant (air) - 1", "0.606"
+
+.. 
+   comment tr_pond_cesm is being deprecated
+   "tr_pond_cesm", ":math:`\bullet` if true, use CESM melt pond scheme", ""

--- a/doc/source/science_guide/sg_thermo.rst
+++ b/doc/source/science_guide/sg_thermo.rst
@@ -105,6 +105,8 @@ the :ref:`tracers` section.
 CESM formulation (``tr_pond_cesm`` = true)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+*Note that the CESM pond option is being deprecated.*
+
 Melt pond area and thickness tracers are carried on each ice thickness
 category as in the :ref:`tracers` section. Defined simply as the product
 of pond area, :math:`a_p`, and depth, :math:`h_p`, the melt pond volume,
@@ -128,7 +130,7 @@ and thickness are computed according to the assumed pond shape, and the
 pond area is then reduced in the presence of snow for the radiation
 calculation. Ponds are allowed only on ice at least 1 cm thick. This
 formulation differs slightly from that documented in
-:cite:`Holland12`. *Note that the CESM pond option has been deprecated.*
+:cite:`Holland12`. 
 
 Topographic formulation (``tr_pond_topo`` = true)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/science_guide/sg_thermo.rst
+++ b/doc/source/science_guide/sg_thermo.rst
@@ -128,7 +128,7 @@ and thickness are computed according to the assumed pond shape, and the
 pond area is then reduced in the presence of snow for the radiation
 calculation. Ponds are allowed only on ice at least 1 cm thick. This
 formulation differs slightly from that documented in
-:cite:`Holland12`.
+:cite:`Holland12`. *Note that the CESM pond option has been deprecated.*
 
 Topographic formulation (``tr_pond_topo`` = true)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/science_guide/sg_tracers.rst
+++ b/doc/source/science_guide/sg_tracers.rst
@@ -78,7 +78,7 @@ the grid cell. These quantities are illustrated in Figure :ref:`fig-tracers`.
 The graphic on the right illustrates the *grid cell* fraction of ponds or 
 level ice as defined by the tracers. The chart on the left provides 
 corresponding ice thickness and pond depth averages over the grid cell, 
-sea ice and pond area fractions. 
+sea ice and pond area fractions. *Note that the cesm pond option has been deprecated.*
 
 .. _fig-tracers:
 

--- a/doc/source/science_guide/sg_tracers.rst
+++ b/doc/source/science_guide/sg_tracers.rst
@@ -45,6 +45,8 @@ is discussed in :cite:`Armour11`.
 Tracers that depend on other tracers 
 ------------------------------------
 
+*Note that the cesm pond option is being deprecated.*
+
 Tracers may be defined that depend on other tracers. Melt pond tracers
 provide an example (these equations pertain to cesm and topo tracers;
 level-ice tracers are similar with an extra factor of :math:`a_{lvl}`,
@@ -78,7 +80,7 @@ the grid cell. These quantities are illustrated in Figure :ref:`fig-tracers`.
 The graphic on the right illustrates the *grid cell* fraction of ponds or 
 level ice as defined by the tracers. The chart on the left provides 
 corresponding ice thickness and pond depth averages over the grid cell, 
-sea ice and pond area fractions. *Note that the cesm pond option has been deprecated.*
+sea ice and pond area fractions. 
 
 .. _fig-tracers:
 

--- a/doc/source/user_guide/interfaces.include
+++ b/doc/source/user_guide/interfaces.include
@@ -2265,7 +2265,7 @@ icepack_init_tracer_flags
   
         subroutine icepack_init_tracer_flags(&
              tr_iage_in, tr_FY_in, tr_lvl_in, &
-             tr_pond_in, tr_pond_cesm_in, tr_pond_lvl_in, tr_pond_topo_in, &
+             tr_pond_in, tr_pond_lvl_in, tr_pond_topo_in, &
              tr_fsd_in, tr_aero_in, tr_iso_in, tr_brine_in, tr_zaero_in, &
              tr_bgc_Nit_in, tr_bgc_N_in, tr_bgc_DON_in, tr_bgc_C_in, tr_bgc_chl_in, &
              tr_bgc_Am_in, tr_bgc_Sil_in, tr_bgc_DMS_in, tr_bgc_Fe_in, tr_bgc_hum_in, &
@@ -2276,7 +2276,6 @@ icepack_init_tracer_flags
                tr_FY_in        , & ! if .true., use first-year area tracer
                tr_lvl_in       , & ! if .true., use level ice tracer
                tr_pond_in      , & ! if .true., use melt pond tracer
-               tr_pond_cesm_in , & ! if .true., use cesm pond tracer
                tr_pond_lvl_in  , & ! if .true., use level-ice pond tracer
                tr_pond_topo_in , & ! if .true., use explicit topography-based ponds
                tr_fsd_in       , & ! if .true., use floe size distribution tracers
@@ -2308,7 +2307,7 @@ icepack_query_tracer_flags
   
         subroutine icepack_query_tracer_flags(&
              tr_iage_out, tr_FY_out, tr_lvl_out, &
-             tr_pond_out, tr_pond_cesm_out, tr_pond_lvl_out, tr_pond_topo_out, &
+             tr_pond_out, tr_pond_lvl_out, tr_pond_topo_out, &
              tr_fsd_out, tr_aero_out, tr_iso_out, tr_brine_out, tr_zaero_out, &
              tr_bgc_Nit_out, tr_bgc_N_out, tr_bgc_DON_out, tr_bgc_C_out, tr_bgc_chl_out, &
              tr_bgc_Am_out, tr_bgc_Sil_out, tr_bgc_DMS_out, tr_bgc_Fe_out, tr_bgc_hum_out, &
@@ -2319,7 +2318,6 @@ icepack_query_tracer_flags
                tr_FY_out        , & ! if .true., use first-year area tracer
                tr_lvl_out       , & ! if .true., use level ice tracer
                tr_pond_out      , & ! if .true., use melt pond tracer
-               tr_pond_cesm_out , & ! if .true., use cesm pond tracer
                tr_pond_lvl_out  , & ! if .true., use level-ice pond tracer
                tr_pond_topo_out , & ! if .true., use explicit topography-based ponds
                tr_fsd_out       , & ! if .true., use floe size distribution

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -183,7 +183,11 @@ tracer_nml
    "``tr_iage``", "logical", "ice age", "``.false.``"
    "``tr_iso``", "logical", "isotopes", "``.false.``"
    "``tr_lvl``", "logical", "level ice area and volume", "``.false.``"
+
+.. comment Note that this has been deprecated.
    "``tr_pond_cesm``", "logical", "CESM melt ponds", "``.false.``"
+
+   "``tr_pond_cesm``", "logical", "DEPRECATED", "``.false.``"
    "``tr_pond_lvl``", "logical", "level-ice melt ponds", "``.false.``"
    "``tr_pond_topo``", "logical", "topo melt ponds", "``.false.``"
    "``tr_snow``", "logical", "advanced snow physics", "``.false.``"

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -183,15 +183,14 @@ tracer_nml
    "``tr_iage``", "logical", "ice age", "``.false.``"
    "``tr_iso``", "logical", "isotopes", "``.false.``"
    "``tr_lvl``", "logical", "level ice area and volume", "``.false.``"
-
-.. comment Note that this has been deprecated.
-   "``tr_pond_cesm``", "logical", "CESM melt ponds", "``.false.``"
-
    "``tr_pond_cesm``", "logical", "DEPRECATED", "``.false.``"
    "``tr_pond_lvl``", "logical", "level-ice melt ponds", "``.false.``"
    "``tr_pond_topo``", "logical", "topo melt ponds", "``.false.``"
    "``tr_snow``", "logical", "advanced snow physics", "``.false.``"
    "", "", "", ""
+
+.. comment tr_pond_cesm is being deprecated
+   "``tr_pond_cesm``", "logical", "CESM melt ponds", "``.false.``"
 
 thermo_nml
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -175,7 +175,7 @@ Some of the options are
 
 ``leap`` which turns on the leap year
 
-``pondcesm``, ``pondlvl``, ``pondtopo`` which turn on the various pond schemes
+``pondlvl``, ``pondtopo`` which turn on the various pond schemes
 
 ``run10day``, ``run1year``, etc which specifies a run length
 

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -261,7 +261,6 @@ Lines that begin with # or are blank are ignored.  For example,
     smoke   col  1x1  debug,run1year  
    restart  col  1x1  debug  
    restart  col  1x1  diag1  
-   restart  col  1x1  pondcesm  
    restart  col  1x1  pondlvl  
    restart  col  1x1  pondtopo  
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Deprecate the CESM Pons
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
160 measured results of 160 total results
159 of 160 tests PASSED
0 of 160 tests PENDING
1 of 160 tests MISSING data
0 of 160 tests FAILED
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [X] Yes
    - [ ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:
This removes tr_pond_cesm and all code related to it. Now in a CPP UNDEPRECATE_CESMPONDS. This will break CICE. However, all base_suite tests (cheyenne/intel) are bfb. The set_nml.cesmponds option was removed from the testsuite. Note that tr_pond_cesm was also removed from the default icepack_in as well. Documentation has been updated with notes that this is deprecated. The one test that failed is missing baseline.

PASS cheyenne_intel_restart_col_1x1_snwgrain_snwITDrdg build
PASS cheyenne_intel_restart_col_1x1_snwgrain_snwITDrdg initialrun
PASS cheyenne_intel_restart_col_1x1_snwgrain_snwITDrdg run 
PASS cheyenne_intel_restart_col_1x1_snwgrain_snwITDrdg test 
MISS cheyenne_intel_restart_col_1x1_snwgrain_snwITDrdg compare icepack.76ecd418d2.220716-085004 missing-data