### PR TITLE
icepack_therm_shared: correct 'Tair' units in declaration comment

### DIFF
--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -295,7 +295,7 @@
          nslyr       ! number of snow layers
 
       real (kind=dbl_kind), intent(in) :: &
-         Tair, &     ! air temperature (C)
+         Tair, &     ! air temperature (K)
          Tf          ! freezing temperature (C)
 
       real (kind=dbl_kind), dimension(:), intent(in) :: &


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me 
- [X] Suggest PR reviewers from list in the column to the right.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

In subroutine icepack_therm_shared::icepack_init_trcr, 'Tair' is
documented as having units 'C' (degrees Celsius), but this is incorrect,
this variable is in Kelvins. This can be seen a few lines below where we
compute Tsfc:

    Tsfc = min(Tsmelt, Tair - Tffresh) ! deg C

where 'Tffresh' is the freezing point of fresh ice in Kelvins, 273.15,
as defined in icepack_parameters.

Fix the units in the declaration comment.

Reported-by: Frederic Dupont <frederic.dupont@canada.ca>