### PR TITLE
snow grain radius bug fix

### DIFF
--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -3712,7 +3712,7 @@
 
          do ks = 1, nslyr
             rsnw(ks)   = max(rsnw_fall,rsnow(ks))
-            rsnw(ks)   = min(rsnw_tmax,rsnow(ks))
+            rsnw(ks)   = min(rsnw_tmax,rsnw (ks))
             rhosnw(ks) = rhos
          enddo
 


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
    Fix snow radius limiting
- [x] Developer(s): 
    @eclare108213 
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.

base_suite:
169 measured results of 169 total results
169 of 169 tests PASSED
0 of 169 tests PENDING
0 of 169 tests MISSING data
0 of 169 tests FAILED

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit in base_suite tests but I would expect the answers to change at some point
    - [ ] different at roundoff level
    - [x] likely more substantial at times, but not expected to be climate-changing
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

When snow metamorphism is active (`snwgrain=.true.`), the snow grain radius takes the tracer value (`rsnow`) but is limited by imposed minimum and maximum snow grain radius parameters.  The minimum is the value assigned for freshly-fallen snow.  The current code only limits the value above, not below.  I expect this change to be non-BFB in runs with snow metamorphism; the current tests may not be long enough or otherwise configured to activate the limiting.  

This is a _single character_ modification!  It was identified during the Icepack-merge-into-E3SM project.