### PR TITLE
Initial, partial deprecation of zsalinity

### DIFF
--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -1057,7 +1057,16 @@
       if (present(modal_aero_in)        ) modal_aero       = modal_aero_in
       if (present(conserv_check_in)     ) conserv_check    = conserv_check_in
       if (present(skl_bgc_in)           ) skl_bgc          = skl_bgc_in
+#ifdef UNDEPRECATE_ZSAL
       if (present(solve_zsal_in)        ) solve_zsal       = solve_zsal_in
+#else
+      if (present(solve_zsal_in)) then
+         if (solve_zsal_in) then
+            call icepack_warnings_add(subname//' zsalinity is being deprecated')
+            call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
+         endif
+      endif
+#endif
       if (present(grid_o_in)            ) grid_o           = grid_o_in
       if (present(l_sk_in)              ) l_sk             = l_sk_in
       if (present(initbio_frac_in)      ) initbio_frac     = initbio_frac_in

--- a/columnphysics/icepack_warnings.F90
+++ b/columnphysics/icepack_warnings.F90
@@ -24,10 +24,10 @@ module icepack_warnings
         icepack_warnings_flush,    &
         icepack_warnings_aborted,  &
         icepack_warnings_add,      &
-        icepack_warnings_setabort
+        icepack_warnings_setabort, &
+        icepack_warnings_getall
 
       private :: &
-        icepack_warnings_getall,   &
         icepack_warnings_getone
 
 !=======================================================================

--- a/columnphysics/icepack_zbgc.F90
+++ b/columnphysics/icepack_zbgc.F90
@@ -45,7 +45,9 @@
       use icepack_algae, only: zbio, sklbio
       use icepack_therm_shared, only: calculate_Tin_from_qin
       use icepack_itd, only: column_sum, column_conservation_check
+#ifdef UNDEPRECATE_ZSAL
       use icepack_zsalinity, only: zsalinity
+#endif
 
       implicit none
 
@@ -1055,6 +1057,7 @@
 
                hbri = hbri + hbrin * aicen(n)
 
+#ifdef UNDEPRECATE_ZSAL
                if (solve_zsal) then
 
                   call zsalinity (n,             dt,                  &
@@ -1083,7 +1086,7 @@
                   if (icepack_warnings_aborted(subname)) return
 
                endif  ! solve_zsal
-
+#endif
             endif ! tr_brine
 
       !-----------------------------------------------------------------

--- a/columnphysics/icepack_zbgc_shared.F90
+++ b/columnphysics/icepack_zbgc_shared.F90
@@ -158,9 +158,12 @@
       real (kind=dbl_kind), parameter, public :: &
          bphimin = 0.03_dbl_kind      ! minimum porosity for zbgc only
 
+#ifdef UNDEPRECATE_ZSAL
+! these parameters are used more generally for zbgc
 !-----------------------------------------------------------------------
 ! Parameters for zsalinity
 !-----------------------------------------------------------------------
+#endif
 
       real (kind=dbl_kind), parameter, public :: &
          viscos_dynamic = 2.2_dbl_kind   , & ! 1.8e-3_dbl_kind (pure water at 0^oC) (kg/m/s)

--- a/columnphysics/icepack_zsalinity.F90
+++ b/columnphysics/icepack_zsalinity.F90
@@ -13,6 +13,12 @@
 !
       module icepack_zsalinity
 
+! zsalinity is being deprecated
+! Additional code cleanup will follow including removal of
+!   solve_zsal, tr_bgc_S, grid_oS, l_skS, iki, and all *zsal*
+!   Rayleigh_real, Rayleigh_criteria
+!   icepack_brine.F90 subroutines icepack_init_zsalinity, compute_microS
+#ifdef UNDEPRECATE_ZSAL
       use icepack_kinds
       use icepack_parameters, only: c0, c1, c2, p001, p5, puny, rhow, depressT, gravit
       use icepack_parameters, only: rhosi, min_salin, salt_loss
@@ -1148,7 +1154,7 @@
       enddo ! k
 
       end subroutine column_sum_zsal
-
+#endif
 !=======================================================================
 
       end module icepack_zsalinity

--- a/columnphysics/icepack_zsalinity.F90
+++ b/columnphysics/icepack_zsalinity.F90
@@ -15,8 +15,8 @@
 
 ! zsalinity is being deprecated
 ! Additional code cleanup will follow including removal of
-!   solve_zsal, tr_bgc_S, grid_oS, l_skS, iki, and all *zsal*
-!   Rayleigh_real, Rayleigh_criteria
+!   solve_zsal, tr_bgc_S, grid_oS, l_skS, iki, TRZS,
+!   Rayleigh_real, Rayleigh_criteria, and all *zsal*
 !   icepack_brine.F90 subroutines icepack_init_zsalinity, compute_microS
 #ifdef UNDEPRECATE_ZSAL
       use icepack_kinds

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -1030,6 +1030,7 @@
       !-----------------------------------------------------------------
       ! zsalinity and brine
       !-----------------------------------------------------------------
+#ifdef UNDEPRECATE_ZSAL
       if (solve_zsal .and. TRZS == 0) then
          write(nu_diag,*) 'WARNING: solve_zsal=T but 0 zsalinity tracers'
          write(nu_diag,*) 'WARNING: setting solve_zsal = F'
@@ -1046,6 +1047,11 @@
          tr_brine = .true.
          ktherm = 1
       endif
+#else
+      if (solve_zsal) then
+         write(nu_diag,*) 'WARNING: zsalinity is being deprecated'
+      endif
+#endif
 
       if (tr_brine .and. TRBRI == 0 ) then
          write(nu_diag,*) &

--- a/configuration/scripts/tests/base_suite.ts
+++ b/configuration/scripts/tests/base_suite.ts
@@ -4,7 +4,6 @@ smoke          col     1x1        debug,run1year
 smoke          col     1x1        debug,bgcispol
 smoke          col     1x1        debug,bgcnice
 smoke          col     1x1        debug,bgcsklnice
-smoke          col     1x1        debug,run1year,zsal
 smoke          col     1x1        debug,run1year,thermo1
 smoke          col     1x1        debug,run1year,swredist
 smoke          col     1x1        debug,run1year,swccsm3
@@ -25,7 +24,6 @@ restart        col     1x1        diag1
 restart        col     1x1        pondlvl
 restart        col     1x1        pondtopo
 restart        col     1x1        bgcispol
-restart        col     1x1        zsal
 restart        col     1x1        thermo1
 restart        col     1x1        swccsm3
 restart        col     1x1        isotope

--- a/configuration/scripts/tests/travis_suite.ts
+++ b/configuration/scripts/tests/travis_suite.ts
@@ -14,7 +14,6 @@ restart        col     1x1        diag1
 restart        col     1x1        pondlvl
 restart        col     1x1        pondtopo
 restart        col     1x1        bgcispol
-restart        col     1x1        zsal
 restart        col     1x1        thermo1
 restart        col     1x1        swccsm3
 restart        col     1x1        isotope

--- a/doc/source/science_guide/sg_bgc.rst
+++ b/doc/source/science_guide/sg_bgc.rst
@@ -129,8 +129,7 @@ difference between the brine height and the equilibrium sea surface.
 Brine height motion is computed in **icepack\_brine.F90** from thermodynamic
 variables and the ice microstructural state
 deduced from internal bulk salinities and temperature. This tracer is
-required for the transport of vertically resolved biogeochemical tracers
-and is closely coupled to the z-salinity prognostic salinity model.
+required for the transport of vertically resolved biogeochemical tracers.
 
 Vertical transport processes are, generally, a result of the brine
 motion. Therefore the vertical transport equations for biogeochemical
@@ -450,10 +449,11 @@ flags in **icepack\_in** must be true: a) ``tr_brine``, b) ``z_tracers``, and c)
    This is appropriate for the black carbon and dust aerosols specified
    by ``tr_zaero`` true.
 
-In addition, a halodynamics scheme must also be used. The default
-thermo-halodynamics is mushy layer ``ktherm`` set to 2. An alternative uses
-the Bitz and Lipscomb thermodynamics ``ktherm`` set to 1 and ``solve_zsal``
-true (referred to as "zsalinity").
+.. zsalinity is being deprecated
+.. In addition, a halodynamics scheme must also be used. The default
+.. thermo-halodynamics is mushy layer ``ktherm`` set to 2. An alternative uses
+.. the Bitz and Lipscomb thermodynamics ``ktherm`` set to 1 and ``solve_zsal``
+.. true (referred to as "zsalinity").
 
 With the above flags, the default biochemistry is a simple
 algal-nitrate system: ``tr_bgc_N`` and ``tr_bgc_Nit`` are true. Options

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -96,7 +96,7 @@ can be modified as needed.
    "NTRAERO", "integer", "number of aerosol tracers", "1"
    "NTRISO", "integer", "number of water isotope tracers", "1"
    "TRBRI", "0,1", "brine height tracer", "0"
-   "TRZS", "0,1", "zsalinity tracer, needs TRBRI=1", "0"
+   "TRZS", "", "DEPRECATED", ""
    "TRBGCS", "0,1", "skeletal layer tracer, needs TRBGCZ=0", "0"
    "TRBGCZ", "0,1", "zbgc tracers, needs TRBGCS=0 and TRBRI=1", "0"
    "NBGCLYR", "integer", "number of zbgc layers", "1"
@@ -499,7 +499,7 @@ zbgc_nml
    "``silicatetype``", "real", "mobility type between stationary and mobile silicate", "-1.0"
    "``skl_bgc``", "logical", "biogeochemistry", "``.false.``"
    "``solve_zbgc``", "logical", "", "``.false.``"
-   "``solve_zsal``", "logical", "update salinity tracer profile", "``.false.``"
+   "``solve_zsal``", "logical", "DEPRECATED", "``.false.``"
    "``tau_max``", "real", "long time mobile to stationary exchanges", "1.73e-5"
    "``tau_min``", "real", "rapid module to stationary exchanges", "5200."
    "``tr_bgc_Am``", "logical", "ammonium tracer", "``.false.``"
@@ -540,6 +540,8 @@ zbgc_nml
 ..   "``restart_bgc``", "logical", "restart tracer values from file", "``.false.``"
 ..   "``restart_hbrine``", "logical", "", "``.false.``"
 ..   "``restart_zsal``", "logical", "", "``.false.``"
+..   "``solve_zsal``", "logical", "update salinity tracer profile", "``.false.``"
+..   "TRZS", "0,1", "zsalinity tracer, needs TRBRI=1", "0"
 
 * = If Icepack is run stand-alone and wave_spec_type is not set to none, then a fixed wave spectrum is defined in the code to use for testing. As with other input data, this spectrum should not be used for production runs or publications.
   

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -228,7 +228,7 @@ i.e. f\_fbio, except they are averaged by ice area.
    "f\_aero", "aerosol mass (snow and ice ssl and int)", "aerosnossl, aerosnoint,aeroicessl, aeroiceint", "kg/kg"
    "f\_fbio", "biological ice to ocean flux", "fN, fDOC, fNit, fAm,fDON,fFep\ :math:`^a`, fFed\ :math:`^a`, fSil,fhum, fPON, fDMSPd,fDMS, fDMSPp, fzaero", "mmol m\ :math:`^{-2}` s\ :math:`^{-1}`"
    "f\_zaero", "bulk z-aerosol mass fraction", "zaero", "kg/kg"
-   "f\_bgc\_S", "bulk z-salinity", "bgc\_S", "ppt"
+   "f\_bgc\_S", "DEPRECATED", "bgc\_S", "ppt"
    "f\_bgc\_N", "bulk algal N concentration", "bgc\_N", "mmol m\ :math:`^{-3}`"
    "f\_bgc\_C", "bulk algal C concentration", "bgc\_C", "mmol m\ :math:`^{-3}`"
    "f\_bgc\_DOC", "bulk DOC concentration", "bgc\_DOC", "mmol m\ :math:`^{-3}`"
@@ -267,3 +267,6 @@ i.e. f\_fbio, except they are averaged by ice area.
 :math:`^b` units are :math:`\mu`\ mol m\ :math:`^{-3}`
 
 :math:`^c` units are :math:`\mu`\ mol m\ :math:`^{-2}`
+
+.. deprecated
+.. "f\_bgc\_S", "bulk z-salinity", "bgc\_S", "ppt"


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
Begin deprecation of the zsalinity code, which provides a prognostic salinity option for use with BL99 thermodynamics.
- [x] Developer(s): 
@eclare108213
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.

base_suite:  all tests are BFB except those with solve_zsal = true, as expected.

162 of 167 tests PASSED
0 of 167 tests PENDING
0 of 167 tests MISSING data
5 of 167 tests FAILED

FAIL conda_macos_smoke_col_1x1_debug_run1year_zsal run
FAIL conda_macos_smoke_col_1x1_debug_run1year_zsal test
FAIL conda_macos_smoke_col_1x1_debug_run1year_zsal compare ibased33 different-data
FAIL conda_macos_restart_col_1x1_zsal run
FAIL conda_macos_restart_col_1x1_zsal test 

The zsalinity tests have now been removed from the scripts.

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit except for tests that include zsalinity, which abort
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [x] Yes, CICE should also abort unless solve_zsal is reset to false internally (as it was in Icepack)
    - [ ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No, it removes a few
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:
The primary module, icepack_zsalinity.F90, has been deactivated via an UNDEPRECATE_ZSAL cpp flag, and the code aborts if solve_zsal = .true.  The code will be cleaned up as part of the E3SM Icepack merge project, including complete removal of all zsalinity related variables, subroutines, conditional statements, and zsal options.
