### PR TITLE
bug fixes for snow grain radius, brine conservation check

### DIFF
--- a/columnphysics/icepack_snow.F90
+++ b/columnphysics/icepack_snow.F90
@@ -31,7 +31,8 @@
 
       real (kind=dbl_kind), parameter, public :: &
          S_r  = 0.033_dbl_kind, & ! irreducible saturation (Anderson 1976)
-         S_wet= 4.22e-5_dbl_kind  ! (um^3/s) wet metamorphism parameters
+         S_wet= 4.22e5_dbl_kind  ! wet metamorphism parameter (um^3/s)
+                                  ! = 1.e18 * 4.22e-13 (Oleson 2010)
 
       real (kind=dbl_kind) :: &
          min_rhos, &   ! snowtable axis data, assumes linear data
@@ -1079,7 +1080,7 @@
       dr_wet = c0
       fliq = c1
       if (smice + smliq > c0 .and. rsnw > c0) then
-         fliq = min(smliq/(smice + smliq),p1)*c100
+         fliq = min(smliq/(smice + smliq),p1)
          dr_wet = S_wet * fliq**3*dt/(c4*pi*rsnw**2)
       endif
 

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -236,7 +236,7 @@
 
          if (tr_brine) then
             vbrin(n) = vbrin(n) + trcrn(nt_fbri,n) &
-                     * vicen(n)/real(nilyr,kind=dbl_kind)
+                     * vicen(n)
          endif
 
          do k = 1, nilyr
@@ -653,7 +653,7 @@
 
          if (tr_brine) then
             vbrin(n) = vbrin(n) + trcrn(nt_fbri,n) &
-                     * vicen(n)/real(nilyr,kind=dbl_kind)
+                     * vicen(n)
          endif
 
          do k = 1, nilyr

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -2800,7 +2800,7 @@
 
          endif   ! aicen_init
 
-         if (snwgrain .and. use_smliq_pnd) then
+         if (snwgrain) then
             call drain_snow (nslyr = nslyr, &
                              vsnon = vsnon(n), &
                              aicen = aicen(n), &


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
This PR corrects the magnitude of a parameter controlling wet metamorphosis of snow (answer changing), and fixes a brine volume conservation check (does not affect the solution).
- [x] Developer(s): 
@eclare108213 
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.

160 measured results of 160 total results
156 of 160 tests PASSED
0 of 160 tests PENDING
2 of 160 tests MISSING data
2 of 160 tests FAILED

Both runs with -s snwgrain have different answers, as expected:
FAIL conda_macos_smoke_col_1x1_debug_run1year_snw30percent_snwgrain compare ibased33 different-data
FAIL conda_macos_restart_col_1x1_snwgrain_snwitdrdg compare ibased33 different-data

This was a change in a recent PR, after the baseline was run - not a problem here:
MISS conda_macos_smoke_col_1x1_debug_fsd12_run1year_short compare ibased33 missing-data
MISS conda_macos_restart_col_1x1_fsd12_short compare ibased33 missing-data

- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [x] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

**Snow parameter**:  Oleson et al eq 3.68:
> dr_e/dt = 10^18 * C1 * f_liq^3 / (4 * pi * r_e^2)
where  
C1 = 4.22e-13 and f_liq = mass fraction of liquid in snow.  

This PR removes a factor of 100 from f_liq in the current code and changes the constant to S_wet = 10^18 * C1 = 4.22e5. 

**Snow drainage**: this change allows wet metamorphism to function when liquid water associated with the snow scheme is not used directly in melt ponds, i.e. `use_smliq_pnd = .false.`  It also fixes a bug in the computation of drained water mass.

**Brine volume**:  this change is only to the before-and-after calculations used to check brine volume conservation.  There is an extra factor of 10 which ought to be removed, if possible, but I'm leaving it in for now.

All bugs were found during the E3SM/Icepack merge process.