### PR TITLE
Implemented fix so that netcdf output works on Ubuntu

### DIFF
--- a/configuration/scripts/machines/Macros.conda_linux
+++ b/configuration/scripts/machines/Macros.conda_linux
@@ -26,6 +26,12 @@ CC := $(SCC)
 FC := $(SFC)
 LD := $(FC)
 
+# Location of the compiled Fortran modules (NetCDF)
+MODDIR  += -I$(CONDA_PREFIX)/include
+
+# Libraries to be passed to the linker
+SLIBS   := -L$(CONDA_PREFIX)/lib -lnetcdf -lnetcdff
+
 # Necessary flag to compile with OpenMP support
 ifeq ($(ICE_THREADED), true)
    LDFLAGS += -fopenmp


### PR DESCRIPTION


## PR checklist
- [X ] Short (1 sentence) summary of your PR: 
    In Macros.conda_linux, add paths to compiled NetCDF module files and libraries.
- [X ] Developer(s): 
    Philippe Blaine provided this fix, David Clemens-Sewall just ran tests and submitted PR.
- [X ] Suggest PR reviewers from list in the column to the right.
  Philippe Blaine, Dave Bailey, or Tony Craig
- [X ] Please copy the PR test results link or provide a summary of testing completed below.
    Icepack base_suite 128 of 128 tests passed. CICE quick_suite 16 of 16 tests passed.
- How much do the PR code changes differ from the unmodified code? 
    - [X ] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X ] No 
- [ ] Please provide any additional information or relevant details below:
