### PR TITLE
driver: icedrv_history: fix start time for NetCDF history output

### DIFF
--- a/configuration/driver/icedrv_calendar.F90
+++ b/configuration/driver/icedrv_calendar.F90
@@ -167,7 +167,7 @@
       tday = (time-sec)/secday + c1     ! absolute day number
 
       ! Convert the current timestep into a calendar date
-      call sec2time(nyr,month,mday,basis_seconds+sec)
+      call sec2time(nyr,month,mday,basis_seconds+time)
 
       yday = mday + daycal(month)  ! day of the year
       nyr = nyr - year_init + 1    ! year number

--- a/configuration/driver/icedrv_calendar.F90
+++ b/configuration/driver/icedrv_calendar.F90
@@ -61,7 +61,6 @@
          year_init, & ! initial year
          nyr      , & ! year number
          idate    , & ! date (yyyymmdd)
-         idate0   , & ! initial date (yyyymmdd)
          sec      , & ! elapsed seconds into date
          npt      , & ! total number of time steps (dt)
          ndtd     , & ! number of dynamics subcycles: dt_dyn=dt/ndtd
@@ -171,8 +170,6 @@
 
       yday = mday + daycal(month)  ! day of the year
       nyr = nyr - year_init + 1    ! year number
-
-      idate0 = (nyr+year_init-1)*10000 + month*100 + mday ! date (yyyymmdd)
 
       end subroutine init_calendar
 

--- a/configuration/driver/icedrv_history.F90
+++ b/configuration/driver/icedrv_history.F90
@@ -68,7 +68,10 @@
          count1(1), count2(2), count3(3), count4(4), & ! cdf start/count arrays
          varid, &                        ! cdf varid
          status, &                       ! cdf status flag
-         iflag                           ! history file attributes
+         iflag, &                        ! history file attributes
+         h0, &                           ! start hour
+         m0, &                           ! start minute
+         s0                              ! start second
 
       character (len=8) :: &
          cdate                           ! date string
@@ -158,6 +161,9 @@
          endif
 
          ! time dimension
+         h0 = sec / 3600 ! Get the current hour
+         m0 = mod(sec, 3600) / 60 ! Get the current minute
+         s0 = mod(sec, 60) ! Get the current seconds
          status = nf90_def_dim(ncid,'time',NF90_UNLIMITED,timid)
          if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: def_dim time')
          status = nf90_def_var(ncid,'time',NF90_DOUBLE,timid,varid)
@@ -165,8 +171,8 @@
          status = nf90_put_att(ncid,varid,'long_name','model time')
          if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: put_att time long_name')
          write(cdate,'(i8.8)') idate0
-         write(tmpstr,'(a,a,a,a,a,a,a,a)') 'days since ', &
-            cdate(1:4),'-',cdate(5:6),'-',cdate(7:8),' 00:00:00'
+         write(tmpstr,'(a,a,a,a,a,a,a,i2.2,a,i2.2,a,i2.2)') 'days since ', &
+            cdate(1:4),'-',cdate(5:6),'-',cdate(7:8),' ',h0,':',m0,':',s0
          status = nf90_put_att(ncid,varid,'units',trim(tmpstr))
          if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: put_att time units')
          if (days_per_year == 360) then

--- a/configuration/driver/icedrv_history.F90
+++ b/configuration/driver/icedrv_history.F90
@@ -69,6 +69,7 @@
          varid, &                        ! cdf varid
          status, &                       ! cdf status flag
          iflag, &                        ! history file attributes
+         sec0, &                         ! number of seconds into the day at istep0
          h0, &                           ! start hour
          m0, &                           ! start minute
          s0                              ! start second
@@ -161,9 +162,10 @@
          endif
 
          ! time dimension
-         h0 = sec / 3600 ! Get the current hour
-         m0 = mod(sec, 3600) / 60 ! Get the current minute
-         s0 = mod(sec, 60) ! Get the current seconds
+         sec0 = int(mod(time0, secday))
+         h0 = sec0 / 3600 ! Get the current hour
+         m0 = mod(sec0, 3600) / 60 ! Get the current minute
+         s0 = mod(sec0, 60) ! Get the current seconds
          status = nf90_def_dim(ncid,'time',NF90_UNLIMITED,timid)
          if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: def_dim time')
          status = nf90_def_var(ncid,'time',NF90_DOUBLE,timid,varid)

--- a/configuration/driver/icedrv_history.F90
+++ b/configuration/driver/icedrv_history.F90
@@ -40,7 +40,7 @@
 
       subroutine history_write()
 
-      use icedrv_calendar, only: idate0, days_per_year, use_leap_years
+      use icedrv_calendar, only: days_per_year, use_leap_years, year_init
       use icedrv_calendar, only: time, time0, secday, istep1, idate, sec
       use icedrv_state, only: aice, vice, vsno, uvel, vvel, divu, shear, strength
       use icedrv_state, only: trcr, trcrn
@@ -162,19 +162,14 @@
          endif
 
          ! time dimension
-         sec0 = int(mod(time0, secday))
-         h0 = sec0 / 3600 ! Get the current hour
-         m0 = mod(sec0, 3600) / 60 ! Get the current minute
-         s0 = mod(sec0, 60) ! Get the current seconds
          status = nf90_def_dim(ncid,'time',NF90_UNLIMITED,timid)
          if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: def_dim time')
          status = nf90_def_var(ncid,'time',NF90_DOUBLE,timid,varid)
          if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: def_var time')
          status = nf90_put_att(ncid,varid,'long_name','model time')
          if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: put_att time long_name')
-         write(cdate,'(i8.8)') idate0
-         write(tmpstr,'(a,a,a,a,a,a,a,i2.2,a,i2.2,a,i2.2)') 'days since ', &
-            cdate(1:4),'-',cdate(5:6),'-',cdate(7:8),' ',h0,':',m0,':',s0
+         write(tmpstr,'(a,i0,a)') 'days since ', &
+            year_init,'-01-01 00:00:00'
          status = nf90_put_att(ncid,varid,'units',trim(tmpstr))
          if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: put_att time units')
          if (days_per_year == 360) then
@@ -290,7 +285,7 @@
 
       status = nf90_inq_varid(ncid,'time',varid)
       if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: inq_var '//'time')
-      value = (time-time0)/secday
+      value = time/secday
       status = nf90_put_var(ncid,varid,value,start=(/timcnt/))
       if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: put_var '//'time')
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X ] Short (1 sentence) summary of your PR: 
    The start time for netCDF output was hardcoded to be at 00:00:00 and there was a bug in icedrv_calendar such that idate0 was fixed at Jan. 1. Both bugs are fixed.
- [X ] Developer(s): 
    David Clemens-Sewall
- [X ] Suggest PR reviewers from list in the column to the right.
- Tony Craig, Dave Bailey 
- [X ] Please copy the PR test results link or provide a summary of testing completed below.
    Icepack base_suite 128/128 passed. CICE quick_suite 16/16 passed.
- How much do the PR code changes differ from the unmodified code? 
    - [X ] bit for bit (except for origin of time dimension in netcdf output)
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X ] No 
- [ ] Please provide any additional information or relevant details below: