### PR TITLE
Corrects thin ice/snow treatment of enthalpy and other tracers

### DIFF
--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -497,7 +497,8 @@
          hovlp           ! overlap between old and new layers (m)
 
       real (kind=dbl_kind) :: &
-         rhlyr           ! 1./hlyr
+         rhlyr,        & ! 1./hlyr
+         qtot            ! total h*q in the column
 
       real (kind=dbl_kind), dimension (nlyr) :: &
          hq              ! h * q for a layer
@@ -509,36 +510,55 @@
       !-----------------------------------------------------------------
 
       rhlyr = c0
-      if (hn > puny) rhlyr = c1 / hlyr
+      if (hn > puny) then
+         rhlyr = c1 / hlyr
 
-      !-----------------------------------------------------------------
-      ! Compute h*q for new layers (k2) given overlap with old layers (k1)
-      !-----------------------------------------------------------------
+         !-----------------------------------------------------------------
+         ! Compute h*q for new layers (k2) given overlap with old layers (k1)
+         !-----------------------------------------------------------------
 
-      do k2 = 1, nlyr
-         hq(k2) = c0
-      enddo                     ! k
-      k1 = 1
-      k2 = 1
-      do while (k1 <= nlyr .and. k2 <= nlyr)
-         hovlp = min (z1(k1+1), z2(k2+1)) &
-               - max (z1(k1),   z2(k2))
-         hovlp = max (hovlp, c0)
-         hq(k2) = hq(k2) + hovlp*qn(k1)
-         if (z1(k1+1) > z2(k2+1)) then
-            k2 = k2 + 1
+         do k2 = 1, nlyr
+            hq(k2) = c0
+         enddo                     ! k
+         k1 = 1
+         k2 = 1
+         do while (k1 <= nlyr .and. k2 <= nlyr)
+            hovlp = min (z1(k1+1), z2(k2+1)) &
+                  - max (z1(k1),   z2(k2))
+            hovlp = max (hovlp, c0)
+            hq(k2) = hq(k2) + hovlp*qn(k1)
+            if (z1(k1+1) > z2(k2+1)) then
+               k2 = k2 + 1
+            else
+               k1 = k1 + 1
+            endif
+         enddo                  ! while
+
+         !-----------------------------------------------------------------
+         ! Compute new enthalpies.
+         !-----------------------------------------------------------------
+
+         do k = 1, nlyr
+            qn(k) = hq(k) * rhlyr
+         enddo                     ! k
+
+      else
+
+         qtot = c0
+         do k = 1, nlyr
+            qtot = qtot + qn(k) * (z1(k+1)-z1(k))
+         enddo
+         if (hn > c0) then
+            do k = 1, nlyr
+               qn(k) = qtot/hn
+            enddo
          else
-            k1 = k1 + 1
+            do k = 1, nlyr
+               qn(k) = c0
+            enddo
          endif
-      enddo                  ! while
 
-      !-----------------------------------------------------------------
-      ! Compute new enthalpies.
-      !-----------------------------------------------------------------
-
-      do k = 1, nlyr
-         qn(k) = hq(k) * rhlyr
-      enddo                     ! k
+      endif
 
       end subroutine adjust_enthalpy
 

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -1706,17 +1706,29 @@
       !-----------------------------------------------------------------
 
       if (ktherm == 2) then
-         if (hsn <= puny) then
+         if (hsn <= puny .or. hin <= c0) then
             do k = 1, nslyr
                fhocnn = fhocnn &
                       + zqsn(k)*hsn/(real(nslyr,kind=dbl_kind)*dt)
                zqsn(k) = -rhos*Lfresh
+!tcx, tcraig, in columnphysics, this is 
+! is it correct that now everything is "if snwgrain"?
+!               if (tr_snow) then
+!                 meltsliq = meltsliq + smicetot(k)  ! add to meltponds
+!                 smice(k) = rhos
+!                 smliq(k) = c0
+!               endif
+!               if (tr_rsnw) rsnw(k) = rsnw_fall
                if (snwgrain) then
                   meltsliq = meltsliq + massice(k)  ! add to meltponds
                   smice(k) = rhos
                   smliq(k) = c0
+                  rsnw(k) = rsnw_fall
                endif
+!tcx
             enddo
+            melts = melts + hsn
+            hsn = c0
             hslyr = c0
          endif
       endif

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -1711,21 +1711,12 @@
                fhocnn = fhocnn &
                       + zqsn(k)*hsn/(real(nslyr,kind=dbl_kind)*dt)
                zqsn(k) = -rhos*Lfresh
-!tcx, tcraig, in columnphysics, this is 
-! is it correct that now everything is "if snwgrain"?
-!               if (tr_snow) then
-!                 meltsliq = meltsliq + smicetot(k)  ! add to meltponds
-!                 smice(k) = rhos
-!                 smliq(k) = c0
-!               endif
-!               if (tr_rsnw) rsnw(k) = rsnw_fall
                if (snwgrain) then
                   meltsliq = meltsliq + massice(k)  ! add to meltponds
                   smice(k) = rhos
                   smliq(k) = c0
                   rsnw(k) = rsnw_fall
                endif
-!tcx
             enddo
             melts = melts + hsn
             hsn = c0


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Corrects thin ice/snow treatment of enthalpy and other tracers
- [X] Developer(s): 
    njeffery
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Icepack is bit-for-bit, CICE is not.  https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#7e0821dcfe824ae99a3bf0cb957497a8e10c4da7
https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#e8a69abde90b99fc6528d469b8698506a99f6e2a
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial for CICE?
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

Adopted from https://github.com/E3SM-Project/E3SM/pull/5630

"This fix redistributes enthalpy and other tracers evenly in snow and ice when their respective thicknesses are < 1e-15 . Previously, these tracers were zero'd non-conservatively. Also corrects a bug in the zeroing of snow thicknesses, and removes snow in thickness_changes if the ice vanishes."

