### PR TITLE
icepack_parameters: don't recompute constants in icepack_query_parameters

### DIFF
--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -1766,9 +1766,6 @@
       if (present(sw_frac_out)           ) sw_frac_out      = sw_frac
       if (present(sw_dtemp_out)          ) sw_dtemp_out     = sw_dtemp
 
-      call icepack_recompute_constants()
-      if (icepack_warnings_aborted(subname)) return
-
       end subroutine icepack_query_parameters
 
 !=======================================================================


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    icepack_parameters: don't recompute constants in icepack_query_parameters
- [X] Developer(s): 
    me
- [X] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    Tested by code inspection.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

All parameters of icepack_parameters::icepack_query_parameters are intent(out), so it does not make sense to recompute constants at the end of that subroutine since no constants are changed. This superfluous call dates back to the introduction of icepack_query_parameters (then called icepack_query_constants) in 7646f2a (Migrate icepack_constants out of the columnphysics/constants directory..., 2017-10-04).

Remove that call.