### PR TITLE
doc: mention code variables relating to 'calc_dragio'

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: doc/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: doc/requirements.txt

--- a/doc/source/science_guide/sg_boundary_forcing.rst
+++ b/doc/source/science_guide/sg_boundary_forcing.rst
@@ -307,7 +307,7 @@ the ocean. If the resulting sea surface temperature falls below the
 salinity-dependent freezing point, then new ice (frazil) forms.
 Otherwise, heat is made available for melting the ice.
 
-The ice-ocean drag coefficient, :math:`c_w`, can optionally be computed from the thickness of the first ocean level, :math:`h_1`, and an under-ice roughness length, :math:`z_{io}`.
+When the namelist option ``calc_dragio`` is set to true, the ice-ocean drag coefficient, :math:`c_w` (``dragio``), is computed from the thickness of the first ocean level, :math:`h_1` (``thickness_ocn_layer1``), and an under-ice roughness length, :math:`z_{io}` (``iceruf_ocn``).
 The computation follows :cite:`Roy15` :
 
 .. math::


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    doc only - no tests.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

At the end of the "Ocean" section, we mention that 'dragio' can be computed from 'iceruf_ocn' and 'thickness_ocn_layer1', but do not mention these code variables, nor the 'calc_dragio' setting used to activate that computation. Mention the code variables next to their mathematical symbol, for more clarity.

Closes https://github.com/CICE-Consortium/Icepack/issues/463
