### PR TITLE
Remove _old options for tfrz_option

### DIFF
--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -393,21 +393,26 @@
 
         character(len=*),parameter :: subname='(icepack_sea_freezing_temperature)'
 
-        if (trim(tfrz_option(1:5)) == 'mushy') then
+        if (trim(tfrz_option) == 'mushy') then
 
            Tf = icepack_liquidus_temperature(sss) ! deg C
 
-        elseif (trim(tfrz_option(1:11)) == 'linear_salt') then
+        elseif (trim(tfrz_option) == 'linear_salt') then
 
            Tf = -depressT * sss ! deg C
 
-        elseif (trim(tfrz_option(1:8)) == 'constant') then
+        elseif (trim(tfrz_option) == 'constant') then
 
            Tf = Tocnfrz
 
-        else
+        elseif (trim(tfrz_option) == 'minus1p8') then
 
            Tf = -1.8_dbl_kind
+
+        else
+
+           call icepack_warnings_add(subname//' tfrz_option unsupported: '//trim(tfrz_option))
+           call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
 
         endif
 

--- a/columnphysics/icepack_tracers.F90
+++ b/columnphysics/icepack_tracers.F90
@@ -7,7 +7,7 @@
       module icepack_tracers
 
       use icepack_kinds
-      use icepack_parameters, only: c0, c1, puny, rhos, rsnw_fall, rhosnew, Tocnfrz, tfrz_option
+      use icepack_parameters, only: c0, c1, puny, rhos, rsnw_fall, rhosnew
       use icepack_parameters, only: snwredist, snwgrain
       use icepack_warnings, only: warnstr, icepack_warnings_add
       use icepack_warnings, only: icepack_warnings_setabort, icepack_warnings_aborted
@@ -1265,16 +1265,7 @@
             else
                trcrn(it) = c0
                if (it == nt_Tsfc) then
-! tcraig, these old options should be deprecated
-! exist for bit-for-bit backwards compatibility in testing
-                  if (tfrz_option == "mushy_old" .or. &
-                      tfrz_option == "linear_salt_old" .or. &
-                      tfrz_option == "constant_old" .or. &
-                      tfrz_option == "minus1p8_old") then
-                     trcrn(it) = Tocnfrz  ! surface temperature
-                  else
-                     trcrn(it) = Tf  ! surface temperature
-                  endif
+                  trcrn(it) = Tf  ! surface temperature
                endif
             endif
 

--- a/configuration/scripts/options/set_nml.alt03
+++ b/configuration/scripts/options/set_nml.alt03
@@ -5,7 +5,7 @@
     sw_redist         = .true.
     sw_frac           = 0.9d0
     sw_dtemp          = 0.02d0
-    tfrz_option       = 'linear_salt_old'
+    tfrz_option       = 'linear_salt'
     conduct           = 'bubbly'
     conserv_check   = .true.
     restore_ocn     = .true.

--- a/configuration/scripts/options/set_nml.alt04
+++ b/configuration/scripts/options/set_nml.alt04
@@ -8,7 +8,7 @@
     sw_redist         = .true.
     sw_frac           = 0.9d0
     sw_dtemp          = 0.02d0
-    tfrz_option       = 'linear_salt_old'
+    tfrz_option       = 'linear_salt'
     conduct           = 'bubbly'
     krdg_partic     = 0
     krdg_redist     = 0

--- a/configuration/scripts/options/set_nml.bgcispol
+++ b/configuration/scripts/options/set_nml.bgcispol
@@ -24,4 +24,4 @@
  tr_bgc_hum      = .true.
  tr_bgc_DON      = .true.
  tr_bgc_Fe       = .false.
- tfrz_option     = 'mushy_old'
+ tfrz_option     = 'mushy'

--- a/configuration/scripts/options/set_nml.bgcnice
+++ b/configuration/scripts/options/set_nml.bgcnice
@@ -24,4 +24,4 @@
  tr_bgc_hum      = .true.
  tr_bgc_DON      = .true.
  tr_bgc_Fe       = .true.
- tfrz_option     = 'mushy_old'
+ tfrz_option     = 'mushy'

--- a/configuration/scripts/options/set_nml.bgcsklnice
+++ b/configuration/scripts/options/set_nml.bgcsklnice
@@ -22,4 +22,4 @@ year_init	 = 2015
  tr_bgc_hum      = .true.
  tr_bgc_DON      = .true.
  tr_bgc_Fe       = .true.
- tfrz_option     = 'mushy_old'
+ tfrz_option     = 'mushy'

--- a/configuration/scripts/options/set_nml.fsd12
+++ b/configuration/scripts/options/set_nml.fsd12
@@ -1,3 +1,3 @@
 tr_fsd = .true.
 wave_spec_type = 'constant'
-tfrz_option    = 'mushy_old'
+tfrz_option    = 'mushy'

--- a/configuration/scripts/options/set_nml.leap
+++ b/configuration/scripts/options/set_nml.leap
@@ -1,3 +1,3 @@
 days_per_year = 365
 use_leap_years = .true.
-tfrz_option    = 'mushy_old'
+tfrz_option    = 'mushy'

--- a/configuration/scripts/options/set_nml.modal
+++ b/configuration/scripts/options/set_nml.modal
@@ -5,5 +5,5 @@ tr_aero      = .true.
 modal_aero   = .true.
 rfracmin     = 0.15
 rfracmax     = 1.0
-tfrz_option  = 'mushy_old'
+tfrz_option  = 'mushy'
 

--- a/configuration/scripts/options/set_nml.thermo1
+++ b/configuration/scripts/options/set_nml.thermo1
@@ -6,5 +6,5 @@ sw_redist         = .true.
 sw_frac           = 0.9d0
 sw_dtemp          = 0.02d0
 conduct = 'MU71'
-tfrz_option = 'linear_salt_old'
+tfrz_option = 'linear_salt'
 atm_data_type = 'clim'


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Remove _old options for tfrz_option
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Full Icepack test suite run on cheyenne, all tests pass.   Several tests changes answer (bgc, alt03, alt04, thermo1) as expected.  Also ran test suite with these modifications within CICE, all tests pass, some results change answer.  https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#2a6741c1ec958858e330b327a4a335fa511f405a
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit, except certain test cases include bgc, alt03, alt04, thermo1
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [X] Yes, requires changes in CICE (see https://github.com/CICE-Consortium/CICE/pull/883) before this version of Icepack can be used in CICE
    - [ ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please provide any additional information or relevant details below:
