### PR TITLE
use -puny in denominator of scaling ratio for flux limiting 

### DIFF
--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -638,7 +638,7 @@
       ! FYI: fside is not yet correct for fsd, may need to adjust fbot further
       !-----------------------------------------------------------------
 
-         xtmp = frzmlt/(fbot + fside + puny)
+         xtmp = frzmlt/(fbot + fside - puny)
          xtmp = min(xtmp, c1)
          fbot  = fbot  * xtmp
          rside = rside * xtmp


### PR DESCRIPTION

- [x] Short (1 sentence) summary of your PR: 
    Fix the sign of puny in the denominator of the ratio used to scale heat fluxes
- [x] Developer(s): 
@njeffery 
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
Bug fix tested in E3SM by @njeffery.  
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [x] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:
Bottom and lateral heat fluxes are limited by the total amount of heat available for melting, and all of these terms are negative.  In particular, fbot+fside<0. Therefore the value of puny needed to keep the denominator from being too small should also be negative.