### PR TITLE
Add gnuplot to the conda environment

### DIFF
--- a/configuration/scripts/machines/environment.yml
+++ b/configuration/scripts/machines/environment.yml
@@ -8,6 +8,8 @@ dependencies:
   - netcdf-fortran
   - netcdf4
   - make
+# Plotting
+  - gnuplot
 # Python dependencies for building the HTML documentation
   - sphinx
   - sphinxcontrib-bibtex

--- a/configuration/scripts/machines/environment.yml
+++ b/configuration/scripts/machines/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - netcdf4
   - make
 # Plotting dependencies
-# - gnuplot
+  - gnuplot
 # Python dependencies for building the HTML documentation
   - sphinx
   - sphinxcontrib-bibtex

--- a/configuration/scripts/machines/environment.yml
+++ b/configuration/scripts/machines/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - netcdf4
   - make
 # Plotting dependencies
-  - gnuplot
+# - gnuplot
 # Python dependencies for building the HTML documentation
   - sphinx
   - sphinxcontrib-bibtex

--- a/configuration/scripts/machines/environment.yml
+++ b/configuration/scripts/machines/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - netcdf-fortran
   - netcdf4
   - make
-# Plotting
+# Plotting dependencies
   - gnuplot
 # Python dependencies for building the HTML documentation
   - sphinx


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Just adds gnuplot to the conda environment.
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
- 
Tested on my Mac conda environment.

[cgdm-hurricane:~/icepack-tutorial/icepack_master] dbailey% conda env create -f configuration/scripts/machines/environment.yml
Channels:
 - conda-forge
Platform: osx-64
Collecting package metadata (repodata.json): done
Solving environment: done

Downloading and Extracting Packages:
                                                                                                                                    
Preparing transaction: done                                                                                                         
Verifying transaction: done                                                                                                         
Executing transaction: done                                                                                                         
#                                                                                                                                   
# To activate this environment, use                                                                                                 
#                                                                                                                                   
#     $ conda activate icepack                                                                                                      
#                                                                                                                                   
# To deactivate an active environment, use                                                                                          
#                                                                                                                                   
#     $ conda deactivate                                                                                                            
                                                                                                                                    
[cgdm-hurricane:~/icepack-tutorial/icepack_master] dbailey% conda activate icepack                                                  
(icepack) [cgdm-hurricane:~/icepack-tutorial/icepack_master] dbailey% which gnuplot
/Users/dbailey/miniconda3/envs/icepack/bin/gnuplot                               
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
This fix allows the timeseries.csh script to be used for Icepack standalone runs.