### PR TITLE
Update derecho gnu, add code coverage capability via lcov

### DIFF
--- a/configuration/scripts/machines/Macros.derecho_gnu
+++ b/configuration/scripts/machines/Macros.derecho_gnu
@@ -11,16 +11,19 @@ FREEFLAGS  := -ffree-form
 FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none -fallow-argument-mismatch
 FFLAGS_NOOPT:= -O0
 
-ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow --std f2008
-#  FFLAGS   += -O0 -g -fcheck=all -finit-real=snan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-  CFLAGS   += -O0
-endif
-
 ifeq ($(ICE_COVERAGE), true)
   FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
   CFLAGS   += -O0 -g -coverage
   LDFLAGS  += -g -ftest-coverage -fprofile-arcs
+else
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow --std f2008
+#  FFLAGS   += -O0 -g -fcheck=all -finit-real=snan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+  CFLAGS   += -O0
+else
+  FFLAGS   += -O2
+  CFLAGS   += -O2
+endif
 endif
 
 SCC   := gcc

--- a/configuration/scripts/machines/Macros.derecho_gnu
+++ b/configuration/scripts/machines/Macros.derecho_gnu
@@ -17,6 +17,12 @@ ifeq ($(ICE_BLDDEBUG), true)
   CFLAGS   += -O0
 endif
 
+ifeq ($(ICE_COVERAGE), true)
+  FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
+  CFLAGS   += -O0 -g -coverage
+  LDFLAGS  += -g -ftest-coverage -fprofile-arcs
+endif
+
 SCC   := gcc
 SFC   := gfortran
 CC := $(SCC)

--- a/configuration/scripts/machines/env.derecho_gnu
+++ b/configuration/scripts/machines/env.derecho_gnu
@@ -10,14 +10,14 @@ if ("$inp" != "-nomodules") then
 source ${MODULESHOME}/init/csh
 
 module --force purge
-module load ncarenv/23.09
+module load ncarenv/24.12
 module load craype
-module load gcc/13.2.0
+module load gcc/12.4.0
 module load ncarcompilers
 #module load cray-mpich/8.1.25
 #module load hdf5/1.12.2
 module load netcdf/4.9.2
-module load cray-libsci/23.09.1.1
+module load cray-libsci/24.03.0
 module load lcov
 
 # For perftools with mpiexec

--- a/configuration/scripts/machines/env.derecho_gnu
+++ b/configuration/scripts/machines/env.derecho_gnu
@@ -39,7 +39,7 @@ setenv OMP_STACKSIZE 64M
 setenv ICE_MACHINE_MACHNAME derecho
 setenv ICE_MACHINE_MACHINFO "HPE Cray EX Milan Slingshot 11"
 setenv ICE_MACHINE_ENVNAME gnu
-setenv ICE_MACHINE_ENVINFO "gcc 13.2.0 20220819, netcdf4.9.2"
+setenv ICE_MACHINE_ENVINFO "gcc 12.4.0, netcdf4.9.2"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR /glade/derecho/scratch/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/campaign/cesm/development/pcwg

--- a/configuration/scripts/machines/env.derecho_gnu
+++ b/configuration/scripts/machines/env.derecho_gnu
@@ -10,14 +10,15 @@ if ("$inp" != "-nomodules") then
 source ${MODULESHOME}/init/csh
 
 module --force purge
-module load ncarenv/23.06
+module load ncarenv/23.09
 module load craype
-module load gcc/12.2.0
+module load gcc/13.2.0
 module load ncarcompilers
 #module load cray-mpich/8.1.25
 #module load hdf5/1.12.2
 module load netcdf/4.9.2
-module load cray-libsci/23.02.1.1
+module load cray-libsci/23.09.1.1
+module load lcov
 
 # For perftools with mpiexec
 # module load perftools-base
@@ -38,7 +39,7 @@ setenv OMP_STACKSIZE 64M
 setenv ICE_MACHINE_MACHNAME derecho
 setenv ICE_MACHINE_MACHINFO "HPE Cray EX Milan Slingshot 11"
 setenv ICE_MACHINE_ENVNAME gnu
-setenv ICE_MACHINE_ENVINFO "gcc 12.2.0 20220819, netcdf4.9.2"
+setenv ICE_MACHINE_ENVINFO "gcc 13.2.0 20220819, netcdf4.9.2"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR /glade/derecho/scratch/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/campaign/cesm/development/pcwg
@@ -49,3 +50,23 @@ setenv ICE_MACHINE_QUEUE "develop"
 setenv ICE_MACHINE_TPNODE 128
 setenv ICE_MACHINE_BLDTHRDS 1
 setenv ICE_MACHINE_QSTAT "qstat "
+
+# For lcov
+#set lcovpath = "/glade/u/home/tcraig/bin"
+#set lcovp5l  = "/glade/u/home/tcraig/usr/lib/perl5/site_perl/5.18.2/x86_64-linux-thread-multi"
+
+#if ($?PATH) then
+#  if ("$PATH" !~ "*${lcovpath}*") then
+#    setenv PATH ${PATH}:$lcovpath
+#  endif
+#else
+#  setenv PATH $lcovpath
+#endif
+
+#if ($?PERL5LIB) then
+#  if ("$PERL5LIB" !~ "*${lcovp5l}*") then
+#    setenv PERL5LIB ${PERL5LIB}:$lcovp5l
+#  endif
+#else
+#  setenv PERL5LIB $lcovp5l
+#endif

--- a/configuration/scripts/tests/icepack.lcov.csh
+++ b/configuration/scripts/tests/icepack.lcov.csh
@@ -6,7 +6,19 @@ lcov ${lcovalist} -o total.info
 
 set lcovrepo = apcraig.github.io
 set lcovhtmldir = lcov_icepack_${report_name}
-genhtml -o ./${lcovhtmldir} --precision 2 -t "${report_name}" total.info
+if ("${useparser}" =~ "true") then
+  #local parsing script
+  mkdir ./${lcovhtmldir}
+  ./parse_lcov.sh >! ./${lcovhtmldir}/${lcovhtmldir}.txt
+  cat >! ./${lcovhtmldir}/index.html <<EOF
+
+<embed type="text/plain" src="${lcovhtmldir}.txt"  width="800" height="20000">
+
+EOF
+else
+  #genhtml
+  genhtml -o ./${lcovhtmldir} --precision 2 -t "${report_name}" total.info
+endif
 
 rm -r -f ${lcovrepo}
 git clone https://github.com/apcraig/${lcovrepo}
@@ -14,7 +26,11 @@ cp -p -r ${lcovhtmldir} ${lcovrepo}/
 
 cd ${lcovrepo}
 set covp0 = `grep message coverage_icepack.json | cut -d : -f 2 | cut -d \" -f 2 | cut -d % -f 1`
-set covp  = `grep -i headerCovTableEntry ${lcovhtmldir}/index.html | grep % | head -1 | cut -d \> -f 2 | cut -d % -f 1`
+if ("${useparser}" =~ "true") then
+  set covp  = `grep "**TOTAL**" ${lcovhtmldir}/${lcovhtmldir}.txt | cut -d \% -f 1`
+else
+  set covp  = `grep -i headerCovTableEntry ${lcovhtmldir}/index.html | grep % | head -1 | cut -d \> -f 2 | cut -d % -f 1`
+endif
 set covpi = `echo $covp | cut -d . -f 1`
 
 set lcovhtmlname = "${covpi}%:${report_name}"

--- a/configuration/scripts/tests/icepack.lcov.csh
+++ b/configuration/scripts/tests/icepack.lcov.csh
@@ -27,9 +27,10 @@ cp -p -r ${lcovhtmldir} ${lcovrepo}/
 cd ${lcovrepo}
 set covp0 = `grep message coverage_icepack.json | cut -d : -f 2 | cut -d \" -f 2 | cut -d % -f 1`
 if ("${useparser}" =~ "true") then
-  set covp  = `grep "**TOTAL**" ${lcovhtmldir}/${lcovhtmldir}.txt | cut -d \% -f 1`
+  set covp = `grep "**TOTAL**" ${lcovhtmldir}/${lcovhtmldir}.txt | cut -d \% -f 1`
 else
-  set covp  = `grep -i headerCovTableEntry ${lcovhtmldir}/index.html | grep % | head -1 | cut -d \> -f 2 | cut -d % -f 1`
+  set covp = `grep -i headerCovTableEntry ${lcovhtmldir}/index.html | grep % | head -1 | cut -d \> -f 2 | cut -d \& -f 1`
+  set covp = "${covp}%"
 endif
 set covpi = `echo $covp | cut -d . -f 1`
 

--- a/configuration/scripts/tests/parse_lcov.sh
+++ b/configuration/scripts/tests/parse_lcov.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+INFILE=total.info
+
+file="ZZZ"
+tfunc=0
+thit=0
+tfnd=0
+dacnt=0
+declare -a func
+declare -a lines
+declare -a linee
+declare -a fhit
+declare -a ffnd
+echo " "
+
+while read -r LINE
+do
+  case $LINE in
+    SF:*)
+      file="${LINE##*/}"
+      ;;
+    FN:*)
+      if [[ "$LINE" =~ ^FN:(.*),(.*),.*_MOD_(.*)$ ]]; then
+        func[$tfunc]="${BASH_REMATCH[3]}"
+        lines[$tfunc]="${BASH_REMATCH[1]}"
+        linee[$tfunc]="${BASH_REMATCH[2]}"
+        fhit[$tfunc]=0
+        ffnd[$tfunc]=0
+        tfunc=$(($tfunc + 1))
+      fi
+      ;;
+    DA:*)
+      if [[ "$LINE" =~ ^DA:(.*),(.*)$ ]]; then
+        lnum="${BASH_REMATCH[1]}"
+        lhit="${BASH_REMATCH[2]}"
+#        echo "tcx3a ${linee[$dacnt]} $lnum $lhit $dacnt"
+        if [[ $lnum -lt ${lines[$dacnt]} || $lnum -gt ${linee[$dacnt]} ]]; then
+          cnt=0
+          while [ $cnt -lt $tfunc ]; do
+            if [[ $lnum -ge ${lines[$cnt]} && $lnum -le ${linee[$cnt]} ]]; then
+              dacnt=$cnt
+            fi
+            cnt=$(($cnt + 1))
+          done
+        fi
+#        echo "tcx3b $lnum $lhit $dacnt"
+        ffnd[$dacnt]=$((ffnd[$dacnt] + 1))
+        if [[ $lhit -gt 0 ]]; then
+          fhit[$dacnt]=$((fhit[$dacnt] + 1))
+        fi
+      fi
+      ;;
+    LF:*)
+      fnd="${LINE##*:}"
+      ;;
+    LH:*)
+      hit="${LINE##*:}"
+      ;;
+    end_of_record)
+      thit=$(($thit + $hit))
+      tfnd=$(($tfnd + $fnd))
+      percent=`echo "scale=2;  $hit * 100. / $fnd" | bc`
+      printf "%6.2f%% %-42s %5d %5d\n" $percent $file $hit $fnd
+      cnt=0
+      while [ $cnt -lt $tfunc ]; do
+        percent=`echo "scale=2;  $((fhit[$cnt] * 100 / ffnd[$cnt]))" | bc`
+#        printf "%6.2f%% %-40s %5d %5d\n" 0 ${func[$cnt]} ${lines[$cnt]} ${linee[$cnt]}
+        printf "%12.2f%% %-36s %5d %5d\n" $percent ${func[$cnt]} ${fhit[$cnt]} ${ffnd[$cnt]}
+        cnt=$(($cnt + 1))
+      done
+      file="ZZZ"
+      tfunc=0
+      dacnt=0
+      ;;
+    *)
+      ;;
+  esac
+
+done < "$INFILE"
+
+echo " "
+#echo "tcx1 $thit $tfnd"
+percent=`echo "scale=2;  $thit * 100. / $tfnd" | bc`
+printf "%6.2f%% %-32s %10d %10d\n" $percent **TOTAL** $thit $tfnd
+echo " "

--- a/icepack.setup
+++ b/icepack.setup
@@ -1003,8 +1003,8 @@ EOF0
   if ($coverage == 1) then
     echo "Generating coverage reports"
     ./poll_queue.csh
-    ./report_lcov.csh -parse
-#    ./report_lcov.csh
+#    ./report_lcov.csh -parse
+    ./report_lcov.csh
 #    ./report_codecov.csh
   endif
   cd ${ICE_SANDBOX}

--- a/icepack.setup
+++ b/icepack.setup
@@ -426,6 +426,7 @@ else
   cp -f ${ICE_SCRIPTS}/tests/report_results.csh ${tsdir}
   cp -f ${ICE_SCRIPTS}/tests/timeseries.csh ${tsdir}
   cp -f ${ICE_SCRIPTS}/tests/poll_queue.csh ${tsdir}
+  cp -f ${ICE_SCRIPTS}/tests/parse_lcov.sh ${tsdir}
 
 cat >! ${tsdir}/suite.run << EOF0
 #!/bin/csh -f
@@ -465,6 +466,21 @@ EOF0
 
 cat >! ${tsdir}/report_codecov.csh << EOF0
 #!/bin/csh -f
+
+set useparser = false
+if (\$#argv > 0) then
+  if (\$#argv > 1) then
+    echo "\${0}: ERROR, -parse is the only optional argument allowed"
+    exit 3
+  else
+    if ("\$argv[1]" =~ "-parse") then
+      set useparser = true
+    else
+      echo "\${0}: ERROR, -parse is the only optional argument allowed"
+      exit 3
+    endif
+  endif
+endif
 
 source ${ICE_SCRIPTS}/machines/env.${machcomp}
 
@@ -903,7 +919,7 @@ cp ${rundir}/compile/*.{gcno,gcda} ${testname_base}/codecov_output/
 EOF
 
 cat >> ${tsdir}/report_lcov.csh << EOF
-lcov --gcov-tool gcov -c -d ${rundir}/compile -o ${testname_base}/lcov.info
+lcov --gcov-tool gcov -c --rc geninfo_unexecuted_blocks=1 -d ${rundir}/compile -o ${testname_base}/lcov.info
 if (-s ${testname_base}/lcov.info) then
   set lcovalist = "\${lcovalist} -a ${testname_base}/lcov.info"
 endif
@@ -917,7 +933,7 @@ echo "${testname_base}"
 cd ${testname_base}
 source ./icepack.settings
 set md5chk = \`where md5sum\`
-if ("\${md5chk}" != "") then
+if ("\${md5chk}" != "" && "${coverage}" == "0") then
   set md5file = icepack.settings.md5
   grep -v " ICE_CASENAME " icepack.settings | grep -v " ICE_CASEDIR " | grep -v " ICE_RUNDIR " | grep -v " ICE_TESTNAME " | grep -v " ICE_TEST " >! \${md5file}
   set icepsetmd5 = \` md5sum \${md5file} | cut -d " " -f 1 \`
@@ -987,7 +1003,8 @@ EOF0
   if ($coverage == 1) then
     echo "Generating coverage reports"
     ./poll_queue.csh
-    ./report_lcov.csh
+    ./report_lcov.csh -parse
+#    ./report_lcov.csh
 #    ./report_codecov.csh
   endif
   cd ${ICE_SANDBOX}


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update derecho gnu, add code coverage capability via lcov
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Results all pass, non-debug tests change answer on derecho gnu with addition of -O2.  https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#3d8b76b9194718c332cc3706f009e8ddc186cd5f
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit, answer changing on derecho gnu due to compiler upgrade
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update derecho gnu to support code coverage testing
- Update to ncarenv/24.12 and gcc/12.4.0
- Add coverage compiler flags
- Add parse_lcov.sh script to support manually parsing lcov info files (not used in production)
- Update lcov scripting as needed

Change derecho gnu non-debug tests to -O2.  This should have always been the case, but was not.  This results in answers changes relative to main but only for derecho gnu with debug off.

As part of the CICE port to the new coverage tools, a bug was found in the tools that requires debug flags to be disabled when compiling with coverage flags.  This was not the case when coverage was running on cheyenne.   See https://github.com/linux-test-project/lcov/issues/385