### PR TITLE
Fix sfc_flux argument order in icepack_therm_vertical.F90

### DIFF
--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -2697,8 +2697,8 @@
                ! hadgem routine sets fluxes to default values in ice-only mode
                call set_sfcflux(aicen      (n),                 &
                                 flatn_f    (n), fsensn_f   (n), &
-                                fcondtopn_f(n),                 &
                                 fsurfn_f   (n),                 &
+                                fcondtopn_f(n),                 &
                                 flatn      (n), fsensn     (n), &
                                 fsurfn     (n),                 &
                                 fcondtopn  (n))


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Fixes `set_sfcflux` argument order in icepack_therm_vertical.F90, this caused errors for models using `calc_tsfc=false`. Addresses #512 
- [x] Developer(s): 
   Kieran Ricardo
- [ ] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    Passed GitHub actions tests: https://github.com/ACCESS-NRI/Icepack/actions/runs/13231902867/job/36930302099?pr=6
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit (except for models using `calc_tsfc=false`)
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [ ] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log. 

The call to `set_sfcflux` in `icepack_therm_vertical.F90` has the `fsurfn_f` and `fcondtopn_f` arguments switched, causing issues for models using `calc_Tsfc = .false.`. This PR fixes these.
