### PR TITLE
Add GEOS coupling capability including heatflux and massflux modifications

### DIFF
--- a/columnphysics/icepack_flux.F90
+++ b/columnphysics/icepack_flux.F90
@@ -43,6 +43,8 @@
                                fhocnn,   fswthrun,   &
                                fswthrun_vdr, fswthrun_vdf,&
                                fswthrun_idr, fswthrun_idf,&
+                               fswthrun_uvrdr, fswthrun_uvrdf,&
+                               fswthrun_pardr, fswthrun_pardf,&
                                strairxT, strairyT,   &
                                Cdn_atm_ratio,        &
                                fsurf,    fcondtop,   &
@@ -56,6 +58,8 @@
                                fhocn,    fswthru,    &
                                fswthru_vdr, fswthru_vdf,&
                                fswthru_idr, fswthru_idf,&
+                               fswthru_uvrdr, fswthru_uvrdf,&
+                               fswthru_pardr, fswthru_pardf,&
                                melttn, meltsn, meltbn, congeln, snoicen, &
                                meltt,  melts,        &
                                meltb,  dsnow, dsnown,&
@@ -102,6 +106,10 @@
           fswthrun_vdf, & ! vis dif sw radiation through ice bot    (W/m**2)
           fswthrun_idr, & ! nir dir sw radiation through ice bot    (W/m**2)
           fswthrun_idf, & ! nir dif sw radiation through ice bot    (W/m**2)
+          fswthrun_uvrdr, & ! vis uvr dir sw radiation through ice bot (GEOS) (W/m**2)
+          fswthrun_uvrdf, & ! vis uvr dif sw radiation through ice bot (GEOS) (W/m**2)
+          fswthrun_pardr, & ! vis par dir sw radiation through ice bot (GEOS) (W/m**2)
+          fswthrun_pardf, & ! vis par dif sw radiation through ice bot (GEOS) (W/m**2)
           Urefn       ! air speed reference level       (m/s)
 
       ! cumulative fluxes
@@ -135,6 +143,10 @@
           fswthru_vdf, & ! vis dif sw radiation through ice bot    (W/m**2)
           fswthru_idr, & ! nir dir sw radiation through ice bot    (W/m**2)
           fswthru_idf, & ! nir dif sw radiation through ice bot    (W/m**2)
+          fswthru_uvrdr, & ! vis uvr dir sw radiation through ice bot (GEOS) (W/m**2)
+          fswthru_uvrdf, & ! vis uvr dif sw radiation through ice bot (GEOS) (W/m**2)
+          fswthru_pardr, & ! vis par dir sw radiation through ice bot (GEOS) (W/m**2)
+          fswthru_pardf, & ! vis par dif sw radiation through ice bot (GEOS) (W/m**2)
           dsnow,    & ! change in snow depth            (m)
           Uref        ! air speed reference level       (m/s)
 
@@ -227,6 +239,15 @@
          fswthru_idr = fswthru_idr + fswthrun_idr  * aicen
       if (present(fswthrun_idf) .and. present(fswthru_idf)) &
          fswthru_idf = fswthru_idf + fswthrun_idf  * aicen
+
+      if (present(fswthrun_uvrdr) .and. present(fswthru_uvrdr)) &
+         fswthru_uvrdr   = fswthru_uvrdr   + fswthrun_uvrdr  * aicen
+      if (present(fswthrun_uvrdf) .and. present(fswthru_uvrdf)) &
+         fswthru_uvrdf   = fswthru_uvrdf   + fswthrun_uvrdf  * aicen
+      if (present(fswthrun_pardr) .and. present(fswthru_pardr)) &
+         fswthru_pardr   = fswthru_pardr   + fswthrun_pardr  * aicen
+      if (present(fswthrun_pardf) .and. present(fswthru_pardf)) &
+         fswthru_pardf   = fswthru_pardf   + fswthrun_pardf  * aicen
 
       ! ice/snow thickness
 

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -155,6 +155,8 @@
          calc_Tsfc     = .true. ,&! if true, calculate surface temperature
                                   ! if false, Tsfc is computed elsewhere and
                                   ! atmos-ice fluxes are provided to CICE
+         geos_heatflux = .false.,&! geos heatflux option
+         geos_massflux = .false.,&! geos massflux option
          update_ocn_f = .false. ,&! include fresh water and salt fluxes for frazil
          solve_zsal   = .false. ,&! if true, update salinity profile from solve_S_dt
          modal_aero   = .false. ,&! if true, use modal aerosal optical properties
@@ -562,7 +564,7 @@
          qqqice_in, TTTice_in, qqqocn_in, TTTocn_in, &
          ktherm_in, conduct_in, fbot_xfer_type_in, calc_Tsfc_in, dts_b_in, &
          update_ocn_f_in, ustar_min_in, hi_min_in, a_rapid_mode_in, &
-         cpl_frazil_in, &
+         cpl_frazil_in, geos_heatflux_in, geos_massflux_in, &
          Rac_rapid_mode_in, aspect_rapid_mode_in, &
          dSdt_slow_mode_in, phi_c_slow_mode_in, &
          phi_i_mushy_in, shortwave_in, albedo_type_in, albsnowi_in, &
@@ -697,6 +699,9 @@
          calc_Tsfc_in    , &! if true, calculate surface temperature
                             ! if false, Tsfc is computed elsewhere and
                             ! atmos-ice fluxes are provided to CICE
+         geos_heatflux_in, &! compute dfsurf/dT, dflat/dT terms instead of fsurf, flat 
+         geos_massflux_in, &! compute mass/enthalpy correction when evaporation/sublimation
+                            ! computed outside at 0C
          update_ocn_f_in    ! include fresh water and salt fluxes for frazil
 
       real (kind=dbl_kind), intent(in), optional :: &
@@ -1166,6 +1171,8 @@
       if (present(conduct_in)           ) conduct          = conduct_in
       if (present(fbot_xfer_type_in)    ) fbot_xfer_type   = fbot_xfer_type_in
       if (present(calc_Tsfc_in)         ) calc_Tsfc        = calc_Tsfc_in
+      if (present(geos_heatflux_in)     ) geos_heatflux    = geos_heatflux_in
+      if (present(geos_massflux_in)     ) geos_massflux    = geos_massflux_in
       if (present(cpl_frazil_in)        ) cpl_frazil       = cpl_frazil_in
       if (present(update_ocn_f_in)      ) update_ocn_f     = update_ocn_f_in
       if (present(dts_b_in)             ) dts_b            = dts_b_in
@@ -1574,8 +1581,8 @@
          Lfresh_out, cprho_out, Cp_out, ustar_min_out, hi_min_out, a_rapid_mode_out, &
          ktherm_out, conduct_out, fbot_xfer_type_out, calc_Tsfc_out, dts_b_out, &
          Rac_rapid_mode_out, aspect_rapid_mode_out, dSdt_slow_mode_out, &
-         phi_c_slow_mode_out, phi_i_mushy_out, shortwave_out, &
-         albedo_type_out, albicev_out, albicei_out, albsnowv_out, &
+         phi_c_slow_mode_out, phi_i_mushy_out, shortwave_out, geos_heatflux_out, &
+         albedo_type_out, albicev_out, albicei_out, albsnowv_out, geos_massflux_out, &
          albsnowi_out, ahmax_out, R_ice_out, R_pnd_out, R_snw_out, dT_mlt_out, &
          rsnw_mlt_out, dEdd_algae_out, &
          kalg_out, R_gC2molC_out, kstrength_out, krdg_partic_out, krdg_redist_out, mu_rdg_out, &
@@ -1715,6 +1722,9 @@
          calc_Tsfc_out    ,&! if true, calculate surface temperature
                             ! if false, Tsfc is computed elsewhere and
                             ! atmos-ice fluxes are provided to CICE
+         geos_heatflux_out,&! compute dfsurf/dT, dflat/dT terms instead of fsurf, flat 
+         geos_massflux_out,&! compute mass/enthalpy correction when evaporation/sublimation
+                            ! computed outside at 0C
          update_ocn_f_out   ! include fresh water and salt fluxes for frazil
 
       real (kind=dbl_kind), intent(out), optional :: &
@@ -2218,6 +2228,8 @@
       if (present(conduct_out)           ) conduct_out      = conduct
       if (present(fbot_xfer_type_out)    ) fbot_xfer_type_out = fbot_xfer_type
       if (present(calc_Tsfc_out)         ) calc_Tsfc_out    = calc_Tsfc
+      if (present(geos_heatflux_out)     ) geos_heatflux_out= geos_heatflux
+      if (present(geos_massflux_out)     ) geos_massflux_out= geos_massflux
       if (present(cpl_frazil_out)        ) cpl_frazil_out   = cpl_frazil
       if (present(update_ocn_f_out)      ) update_ocn_f_out = update_ocn_f
       if (present(dts_b_out)             ) dts_b_out        = dts_b
@@ -2528,6 +2540,8 @@
         write(iounit,*) "  conduct    = ", trim(conduct)
         write(iounit,*) "  fbot_xfer_type = ", trim(fbot_xfer_type)
         write(iounit,*) "  calc_Tsfc  = ", calc_Tsfc
+        write(iounit,*) "  geos_heatflux = ", geos_heatflux
+        write(iounit,*) "  geos_massflux = ", geos_massflux
         write(iounit,*) "  cpl_frazil = ", cpl_frazil
         write(iounit,*) "  update_ocn_f = ", update_ocn_f
         write(iounit,*) "  dts_b      = ", dts_b

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -29,7 +29,7 @@
       use icepack_parameters, only: phi_init, dsin0_frazil, salt_loss
       use icepack_parameters, only: Tliquidus_max
       use icepack_parameters, only: rhosi, conserv_check, rhosmin, snwredist
-      use icepack_parameters, only: kitd, ktherm
+      use icepack_parameters, only: kitd, ktherm, geos_heatflux
       use icepack_parameters, only: z_tracers, hfrazilmin, hi_min
       use icepack_parameters, only: cpl_frazil, update_ocn_f, saltflux_option
       use icepack_parameters, only: icepack_chkoptargflag
@@ -2016,7 +2016,9 @@
       ! Let rain drain through to the ocean.
       !-----------------------------------------------------------------
 
-      fresh  = fresh + frain * aice
+      if (.not.geos_heatflux) then  ! include rain drainage
+         fresh  = fresh + frain * aice
+      endif
 
       !-----------------------------------------------------------------
       ! Given thermodynamic growth rates, transport ice between

--- a/columnphysics/icepack_therm_mushy.F90
+++ b/columnphysics/icepack_therm_mushy.F90
@@ -6,7 +6,7 @@
   use icepack_parameters, only: c0, c1, c2, c8, c10
   use icepack_parameters, only: p01, p05, p1, p2, p5, pi, bignum, puny
   use icepack_parameters, only: viscosity_dyn, rhow, rhoi, rhos, cp_ocn, cp_ice, Lfresh, gravit, rhofresh
-  use icepack_parameters, only: hs_min, snwgrain
+  use icepack_parameters, only: hs_min, snwgrain, geos_heatflux
   use icepack_parameters, only: a_rapid_mode, Rac_rapid_mode, tscale_pnd_drain
   use icepack_parameters, only: aspect_rapid_mode, dSdt_slow_mode, phi_c_slow_mode
   use icepack_parameters, only: sw_redist, sw_frac, sw_dtemp
@@ -19,6 +19,8 @@
   use icepack_mushy_physics, only: conductivity_mush_array, conductivity_snow_array
   use icepack_therm_shared, only: surface_heat_flux, dsurface_heat_flux_dTsf
   use icepack_therm_shared, only: ferrmax
+  use icepack_therm_shared, only: fsurf_cpl, flat_cpl, dfsurfdTs_cpl, dflatdTs_cpl
+  use icepack_therm_shared, only: fsurf_cpl0, flat_cpl0
   use icepack_warnings, only: warnstr, icepack_warnings_add
   use icepack_warnings, only: icepack_warnings_setabort, icepack_warnings_aborted
 
@@ -841,6 +843,11 @@
     else
        ! initially melting
 
+       if (geos_heatflux) then  ! update surf/lat hf based on dT
+          fsurf_cpl = fsurf_cpl + dfsurfdTs_cpl * (Tmlt - Tsf)
+          flat_cpl  = flat_cpl  + dflatdTs_cpl  * (Tmlt - Tsf)
+       endif
+
        ! solve the system for melt and no snow
        Tsf = Tmlt
 
@@ -884,6 +891,11 @@
           ! assume surface is cold
           fcondtop1 = fcondtop
           fsurfn1   = fsurfn
+
+          if (geos_heatflux) then  ! initialize
+             fsurf_cpl = fsurf_cpl0
+             flat_cpl  = flat_cpl0
+          endif
 
           ! reset the solution to initial values
           Tsf  = Tsf0
@@ -1226,24 +1238,36 @@
     zTsn_prev = zTsn
     zTin_prev = zTin
 
+    if (geos_heatflux) then  ! surf/lat hf from coupler, d(surf/lat)/dT computed
+       dfsurfn_dTsf  = dfsurfdTs_cpl
+       dflatn_dTsf   = dflatdTs_cpl
+       fsurfn        = fsurf_cpl
+       flatn         = flat_cpl
+       fsurfn        = fsurfn + fswsfc
+       flwoutn       = c0 !prevent compiler warning
+       fsensn        = c0 !prevent compiler warning
+    endif
+
     ! picard iteration
     picard: do nit = 1, nit_max
 
-       ! surface heat flux
-       call surface_heat_flux(Tsf,     fswsfc, &
-                              rhoa,    flw,    &
-                              potT,    Qa,     &
-                              shcoef,  lhcoef, &
-                              flwoutn, fsensn, &
-                              flatn,   fsurfn)
-       if (icepack_warnings_aborted(subname)) return
+       if (.not.geos_heatflux) then  ! no surface heat flux calculation
+          ! surface heat flux
+          call surface_heat_flux(Tsf,     fswsfc, &
+                                 rhoa,    flw,    &
+                                 potT,    Qa,     &
+                                 shcoef,  lhcoef, &
+                                 flwoutn, fsensn, &
+                                 flatn,   fsurfn)
+          if (icepack_warnings_aborted(subname)) return
 
-       ! derivative of heat flux with respect to surface temperature
-       call dsurface_heat_flux_dTsf(Tsf,          rhoa,          &
-                                    shcoef,       lhcoef,        &
-                                    dfsurfn_dTsf, dflwoutn_dTsf, &
-                                    dfsensn_dTsf, dflatn_dTsf)
-       if (icepack_warnings_aborted(subname)) return
+          ! derivative of heat flux with respect to surface temperature
+          call dsurface_heat_flux_dTsf(Tsf,          rhoa,          &
+                                       shcoef,       lhcoef,        &
+                                       dfsurfn_dTsf, dflwoutn_dTsf, &
+                                       dfsensn_dTsf, dflatn_dTsf)
+          if (icepack_warnings_aborted(subname)) return
+       endif
 
        ! tridiagonal solve of new temperatures
        call solve_heat_conduction(lsnow,     lcold,        &
@@ -1289,6 +1313,11 @@
                                      fadvheat_nit)
        if (icepack_warnings_aborted(subname)) return
 
+       if (geos_heatflux) then  ! update surf/lat hf based on dT
+          fsurfn = fsurfn + (Tsf - Tsf_prev)*dfsurfn_dTsf
+          flatn  = flatn  + (Tsf - Tsf_prev)*dflatn_dTsf
+       endif
+
        if (lconverged) exit
 
        Tsf_prev  = Tsf
@@ -1312,13 +1341,15 @@
     if (icepack_warnings_aborted(subname)) return
 
     ! final surface heat flux
-    call surface_heat_flux(Tsf,     fswsfc, &
-                           rhoa,    flw,    &
-                           potT,    Qa,     &
-                           shcoef,  lhcoef, &
-                           flwoutn, fsensn, &
-                           flatn,   fsurfn)
-    if (icepack_warnings_aborted(subname)) return
+    if (.not.geos_heatflux) then  ! no surface heat flux calculation
+       call surface_heat_flux(Tsf,     fswsfc, &
+                              rhoa,    flw,    &
+                              potT,    Qa,     &
+                              shcoef,  lhcoef, &
+                              flwoutn, fsensn, &
+                              flatn,   fsurfn)
+       if (icepack_warnings_aborted(subname)) return
+    endif
 
     ! if not converged
     if (.not. lconverged) then

--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -48,6 +48,14 @@
       logical (kind=log_kind), public :: &
          l_brine         ! if true, treat brine pocket effects
 
+      real (kind=dbl_kind), public :: &
+         dfsurfdTs_cpl,      & !
+         dflatdTs_cpl,       & !
+         fsurf_cpl0,         & !
+         flat_cpl0,          & !
+         fsurf_cpl,          & !
+         flat_cpl              !
+
 !=======================================================================
 
       contains

--- a/configuration/driver/icedrv_init.F90
+++ b/configuration/driver/icedrv_init.F90
@@ -112,7 +112,7 @@
       real (kind=dbl_kind) :: ice_ref_salinity
 
       logical (kind=log_kind) :: calc_Tsfc, formdrag, highfreq, calc_strair, calc_dragio
-      logical (kind=log_kind) :: conserv_check
+      logical (kind=log_kind) :: conserv_check, geos_heatflux, geos_massflux
 
       integer (kind=int_kind) :: ntrcr
       logical (kind=log_kind) :: tr_iage, tr_FY, tr_lvl, tr_pond, tr_snow
@@ -183,7 +183,8 @@
         atm_data_file,   ocn_data_file,   bgc_data_file,   &
         ice_data_file,                                     &
         atm_data_format, ocn_data_format, bgc_data_format, &
-        data_dir,        trestore,        restore_ocn
+        data_dir,        trestore,        restore_ocn,     &
+        geos_heatflux,   geos_massflux
 
       namelist /tracer_nml/   &
         tr_iage,      &
@@ -217,6 +218,7 @@
            rfracmin_out=rfracmin, rfracmax_out=rfracmax, &
            pndaspect_out=pndaspect, hs1_out=hs1, hp1_out=hp1, &
            ktherm_out=ktherm, calc_Tsfc_out=calc_Tsfc, &
+           geos_heatflux_out=geos_heatflux, geos_massflux_out=geos_massflux, &
            floediam_out=floediam, hfrazilmin_out=hfrazilmin, &
            update_ocn_f_out = update_ocn_f, cpl_frazil_out = cpl_frazil, &
            conduct_out=conduct, a_rapid_mode_out=a_rapid_mode, &
@@ -765,6 +767,8 @@
          write(nu_diag,1010) ' calc_strair               = ', calc_strair
          write(nu_diag,1010) ' calc_Tsfc                 = ', calc_Tsfc
          write(nu_diag,1010) ' calc_dragio               = ', calc_dragio
+         write(nu_diag,1010) ' geos_heatflux             = ', geos_heatflux
+         write(nu_diag,1010) ' geos_massflux             = ', geos_massflux
          write(nu_diag,1005) ' floediam                  = ', floediam
          write(nu_diag,1005) ' hfrazilmin                = ', hfrazilmin
 
@@ -976,6 +980,7 @@
            pndaspect_in=pndaspect, hs1_in=hs1, hp1_in=hp1, &
            floediam_in=floediam, hfrazilmin_in=hfrazilmin, &
            ktherm_in=ktherm, calc_Tsfc_in=calc_Tsfc, &
+           geos_heatflux_in=geos_heatflux, geos_massflux_in=geos_massflux, &
            conduct_in=conduct, a_rapid_mode_in=a_rapid_mode, &
            update_ocn_f_in=update_ocn_f, cpl_frazil_in=cpl_frazil, &
            Rac_rapid_mode_in=Rac_rapid_mode, &

--- a/configuration/scripts/icepack_in
+++ b/configuration/scripts/icepack_in
@@ -137,6 +137,8 @@
     atm_data_format = 'bin'
     ocn_data_format = 'bin'
     bgc_data_format = 'bin'
+    geos_heatflux   = .false.
+    geos_massflux   = .false.
 /
 
 &dynamics_nml

--- a/configuration/scripts/machines/env.discover_intel
+++ b/configuration/scripts/machines/env.discover_intel
@@ -47,7 +47,7 @@ setenv ICE_MACHINE_WKDIR /discover/nobackup/$user/ICEPACK_RUNS
 setenv ICE_MACHINE_INPUTDATA /discover/nobackup/sakella/icepack_data
 setenv ICE_MACHINE_BASELINE /discover/nobackup/$user/ICEPACK_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch"
-setenv ICE_MACHINE_ACCT g0613
+setenv ICE_MACHINE_ACCT g0609
 setenv ICE_MACHINE_QUEUE "share"
 setenv ICE_MACHINE_TPNODE 36
 setenv ICE_MACHINE_BLDTHRDS 1

--- a/doc/source/science_guide/sg_boundary_forcing.rst
+++ b/doc/source/science_guide/sg_boundary_forcing.rst
@@ -88,7 +88,16 @@ stable and accurate procedure would be to compute the temperature
 profiles for both the atmosphere and ice, together with the surface	
 fluxes, in a single implicit calculation. This was judged impractical,	
 however, given that the atmosphere and sea ice models generally exist on	
-different grids and/or processor sets.
+different grids and/or processor sets. In NASA GMAO GEOS-ESM coupled model, 
+a semi-implicit thermodynamic coupling scheme is introduced. Similar to the explicit
+case, the fields ``fsurfn`` are provided by the coupler, along with their derivatives
+with respect to surface temperature ``dfsurfn_dTs``. In this case, ``calc_Tsfc``
+is still set to true, allowing ice surface and internal temperature to be updated
+implicitly. The resultant surface temperature change is passed back to the
+atmosphere model via coupler to complete the full update of its temperature profiles.
+This middle-ground approach, enabled by ``enforcing_heatflux=true``, does not sacrifice accuracy because it does not need limiting effective conductivity as in the explicit case.
+
+      
 
 .. _atmo:
 

--- a/doc/source/science_guide/sg_thermo.rst
+++ b/doc/source/science_guide/sg_thermo.rst
@@ -1802,7 +1802,12 @@ ice), and :math:`L_v = 2.501 \times 10^6 \ \mathrm{J/kg}` is the latent
 heat of vaporization of liquid water at :math:`0^{\circ}C`. Note that :math:`\rho L_v` is
 nearly an order of magnitude larger than typical values of :math:`q`.
 For positive latent heat fluxes, the deposited snow or ice is assumed to
-have the same enthalpy as the existing surface layer.
+have the same enthalpy as the existing surface layer. Some climate models (for 
+example, GEOS-ESM) compute mass flux (sublimation or deposition) in the atmsophere 
+model which assumes vapor deposits or sublimates at 0 degC. In this case, mass
+conservation is enforced and the resulting discrepancy in energy is resolved by
+another term ``sblx`` and passed to ocean. This option is only on when 
+``enforcing_massflux = true``.      
 
 After growth and melting, the various ice layers no longer have equal
 thicknesses. We therefore adjust the layer interfaces, conserving

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -357,6 +357,8 @@ forcing_nml
    "", "``constant``", "constant ocean heat transfer coefficient", ""
    "``formdrag``", "logical", "calculate form drag", "``.false.``"
    "``fyear_init``", "integer", "first year of atmospheric forcing data", "1998"
+   "``geos_heatflux``", "logical", "GEOS heatflux coupling calculation based on d(hf)/dTs", "``.false.``"
+   "``geos_massflux``", "logical", "GEOS mass/enthalpy coupling adjustment", "``.false.``"
    "``highfreq``", "logical", "high-frequency atmo coupling", "``.false.``"
    "``lateral_flux_type``", "``uniform_ice``", "flux ice with identical properties into the cell when closing (Icepack only)", ""
    "", "``none``", "advect open water into the cell when closing (Icepack only)", ""


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Add GEOS coupling capability including heatflux and massflux modifications
- [X] Developer(s): 
    zhaobin74, apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Standalone model is bit-for-bit, testing continues.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Add GEOS heatflux and massflux updates.  This allows coupling to the GEOS
coupled system where a semi-implicit thermodynamic coupling scheme is introduced. Similar to the explicit case, the fields fsurfn are provided by the coupler, along with their derivatives with respect to surface temperature dfsurfn_dTs. In this case, calc_Tsfc is still set to true, allowing ice surface and internal temperature to be updated implicitly. The resultant surface temperature change is passed back to the atmosphere model via coupler to complete the full update of its temperature profiles. This middle-ground approach, enabled by geos_heatflux=true, does not sacrifice accuracy because it does not need limiting effective conductivity as in the explicit case. In addition, in GEOS, the atmsophere
model assumes vapor deposits or sublimates at 0 degC. In this case, mass conservation is enforced and the resulting discrepancy in energy is resolved by another term sblx and passed to ocean. This option is only on when geos_massflux=true.

- Add 4 new shortwave terms, uvrdr, uvrdf, pardr, pardf to the coupling.  These terms represent a breakdown of the direct and diffuse visible shortwave terms into two components, par = photosynthetical active radiation and uvr = rest of the visible shortwave term.  The current visible shortwave is exactly represented by these two components.  Includes adding atm forcing and terms associated with radiation passthru to the ocean.

- Add calculation of GEOS heatflux.  In GEOS, surface and latent heat flux is computed in the atmosphere at 0degC.  The sea ice model has to respect that calculation, but then computes the d(dh)/dTs terms to correct the heatflux for the sea ice temperature which is then applied conservatively in the coupled system. Implementation includes turning off some of the heat flux calculations in Icepack.

- Add calculation of GEOS massflux term.  An equivalent correction is needed to the mass and enthalpy terms to take into account the GEOS coupling.

- Add geos_heatflux and geos_massflux to parameters and namelist input

- Update discover port

- Update documentation

