### PR TITLE
Update ponds diagnostics and names

### DIFF
--- a/columnphysics/icepack_flux.F90
+++ b/columnphysics/icepack_flux.F90
@@ -69,11 +69,11 @@
                                Qref_iso, Qrefn_iso,  &
                                fiso_ocn, fiso_ocnn,  &
                                fiso_evap, fiso_evapn,&
-                               flpnd,  flpndn,       &
-                               expnd,  expndn,       &
-                               frpnd,  frpndn,       &
-                               rfpnd,  rfpndn,       &
-                               ilpnd,  ilpndn)
+                               dpnd_flush,   dpnd_flushn,   &
+                               dpnd_expon,   dpnd_exponn,   &
+                               dpnd_freebd,  dpnd_freebdn,  &
+                               dpnd_initial, dpnd_initialn, &
+                               dpnd_dlid,    dpnd_dlidn)
 
       ! single category fluxes
       real (kind=dbl_kind), intent(in) :: &
@@ -107,11 +107,11 @@
           dsnown  , & ! change in snow depth            (m)
           congeln , & ! congelation ice growth          (m)
           snoicen , & ! snow-ice growth                 (m)
-          flpndn  , & ! pond flushing rate due to ice permeability (m/step)
-          expndn  , & ! exponential pond drainage rate (m/step)
-          frpndn  , & ! pond drainage rate due to freeboard constraint (m/step)
-          rfpndn  , & ! runoff rate due to rfrac (m/step)
-          ilpndn  , & ! pond loss/gain due to ice lid (m/step)
+          dpnd_flushn , & ! pond flushing rate due to ice permeability (m/step)
+          dpnd_exponn , & ! exponential pond drainage rate (m/step)
+          dpnd_freebdn, & ! pond drainage rate due to freeboard constraint (m/step)
+          dpnd_initialn,& ! runoff rate due to rfrac (m/step)
+          dpnd_dlidn  , & ! pond loss/gain due to ice lid (m/step)
           fswthrun_vdr, & ! vis dir sw radiation through ice bot    (W/m**2)
           fswthrun_vdf, & ! vis dif sw radiation through ice bot    (W/m**2)
           fswthrun_idr, & ! nir dir sw radiation through ice bot    (W/m**2)
@@ -149,11 +149,11 @@
           meltsliq, & ! mass of snow melt               (kg/m^2)
           congel  , & ! congelation ice growth          (m)
           snoice  , & ! snow-ice growth                 (m)
-          flpnd   , & ! pond flushing rate due to ice permeability (m/step)
-          expnd   , & ! exponential pond drainage rate (m/step)
-          frpnd   , & ! pond drainage rate due to freeboard constraint (m/step)
-          rfpnd   , & ! runoff rate due to rfrac (m/step)
-          ilpnd   , & ! pond loss/gain (+/-) to ice lid freezing/melting (m/step)
+          dpnd_flush , & ! pond flushing rate due to ice permeability (m/step)
+          dpnd_expon , & ! exponential pond drainage rate (m/step)
+          dpnd_freebd, & ! pond drainage rate due to freeboard constraint (m/step)
+          dpnd_initial,& ! runoff rate due to rfrac (m/step)
+          dpnd_dlid  , & ! pond loss/gain (+/-) to ice lid freezing/melting (m/step)
           fswthru_vdr, & ! vis dir sw radiation through ice bot    (W/m**2)
           fswthru_vdf, & ! vis dif sw radiation through ice bot    (W/m**2)
           fswthru_idr, & ! nir dir sw radiation through ice bot    (W/m**2)
@@ -285,16 +285,16 @@
          snoice    = snoice    + snoicen   * aicen
       ! Meltwater fluxes
       if (tr_pond) then
-         if (present(flpndn) .and. present(flpnd)) &
-            flpnd     = flpnd     + flpndn    * aicen
-         if (present(expndn) .and. present(expnd)) &
-            expnd     = expnd     + expndn    * aicen
-         if (present(frpndn) .and. present(frpnd)) &
-            frpnd     = frpnd     + frpndn    * aicen
-         if (present(rfpndn) .and. present(rfpnd)) &
-            rfpnd     = rfpnd     + rfpndn    * aicen
-         if (present(ilpndn) .and. present(ilpnd)) &
-            ilpnd     = ilpnd     + ilpndn    * aicen
+         if (present(dpnd_flushn)  .and. present(dpnd_flush))   &
+            dpnd_flush   = dpnd_flush   + dpnd_flushn   * aicen
+         if (present(dpnd_exponn)  .and. present(dpnd_expon))   &
+            dpnd_expon   = dpnd_expon   + dpnd_exponn   * aicen
+         if (present(dpnd_freebdn) .and. present(dpnd_freebd))  &
+            dpnd_freebd  = dpnd_freebd  + dpnd_freebdn  * aicen
+         if (present(dpnd_initialn).and. present(dpnd_initial)) &
+            dpnd_initial = dpnd_initial + dpnd_initialn * aicen
+         if (present(dpnd_dlidn)   .and. present(dpnd_dlid))    &
+            dpnd_dlid    = dpnd_dlid    + dpnd_dlidn    * aicen
       endif
 
       end subroutine merge_fluxes

--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -297,7 +297,7 @@
       subroutine reduce_area (hin_max,            &
                               aicen,     vicen,   &
                               aicen_init,vicen_init, &
-                              mipnd, trcrn)
+                              dpnd_melt, trcrn)
 
       real (kind=dbl_kind), intent(in) :: &
          hin_max       ! lowest category boundary
@@ -305,7 +305,7 @@
       real (kind=dbl_kind), intent(inout) :: &
          aicen     , & ! concentration of ice
          vicen     , & ! volume per unit area of ice          (m)
-         mipnd         ! pond 'drainage' due to ice melting (m / step)
+         dpnd_melt     ! pond 'drainage' due to ice melting (m / step)
 
       real (kind=dbl_kind), intent(in) :: &
          aicen_init, & ! old ice area for category 1 (m)
@@ -351,9 +351,9 @@
             da = da - aicen ! -1*change in fractional area over the subroutine
             if (tr_pond) then
                if (tr_pond_lvl) then
-                  mipnd = da*trcrn(nt_apnd,1)*trcrn(nt_hpnd,1)*trcrn(nt_alvl,1)
+                  dpnd_melt = da*trcrn(nt_apnd,1)*trcrn(nt_hpnd,1)*trcrn(nt_alvl,1)
                else
-                  mipnd = da*trcrn(nt_apnd,1)*trcrn(nt_hpnd,1)
+                  dpnd_melt = da*trcrn(nt_apnd,1)*trcrn(nt_hpnd,1)
                endif
             endif
 

--- a/columnphysics/icepack_mechred.F90
+++ b/columnphysics/icepack_mechred.F90
@@ -109,7 +109,7 @@
                             dardg1ndt,   dardg2ndt,  &
                             dvirdgndt,   Tf,         &
                             araftn,      vraftn,     &
-                            closing,     rdpnd)
+                            closing,     dpnd_ridge)
 
       integer (kind=int_kind), intent(in) :: &
          ndtd       ! number of dynamics subcycles
@@ -167,7 +167,7 @@
          fpond      , & ! fresh water flux to ponds (kg/m^2/s)
          fresh      , & ! fresh water flux to ocean (kg/m^2/s)
          fhocn      , & ! net heat flux to ocean (W/m^2)
-         rdpnd          ! pond drainage due to ridging (m avg. over cell)
+         dpnd_ridge     ! pond drainage due to ridging (m avg. over cell)
 
       real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
          dardg1ndt  , & ! rate of fractional area loss by ridging ice (1/s)
@@ -609,7 +609,7 @@
       if (present(fpond)) then
          fpond = fpond - mpond ! units change later
       endif
-      if (present(rdpnd)) rdpnd = mpond
+      if (present(dpnd_ridge)) dpnd_ridge = mpond
 
       !-----------------------------------------------------------------
       ! Check for fractional ice area > 1.
@@ -1752,7 +1752,7 @@
                                     aice,         fsalt,         &
                                     first_ice,                   &
                                     flux_bio,     closing,       &
-                                    Tf,           rdpnd,         &
+                                    Tf,           dpnd_ridge,    &
                                     docleanup,    dorebin)
 
       real (kind=dbl_kind), intent(in) :: &
@@ -1826,7 +1826,7 @@
          first_ice    ! true until ice forms
 
       real (kind=dbl_kind), intent(inout), optional :: &
-         rdpnd        ! pond drainage due to ridging
+         dpnd_ridge   ! pond drainage due to ridging
 
      logical (kind=log_kind), intent(in), optional ::   &
          docleanup, & ! if false, do not call cleanup_itd (default true)
@@ -1904,7 +1904,7 @@
                       dardg1ndt,    dardg2ndt,      &
                       dvirdgndt,    Tf,             &
                       araftn,       vraftn,         &
-                      closing,      rdpnd )
+                      closing,      dpnd_ridge )
       if (icepack_warnings_aborted(subname)) return
 
       !-----------------------------------------------------------------

--- a/columnphysics/icepack_meltpond_lvl.F90
+++ b/columnphysics/icepack_meltpond_lvl.F90
@@ -42,9 +42,11 @@
                                    qicen,  sicen,        &
                                    Tsfcn,  alvl,         &
                                    apnd,   hpnd,  ipnd,  &
-                                   meltsliqn, frpndn,    &
-                                   rfpndn, ilpndn,       &
-                                   flpndn)
+                                   meltsliqn,            &
+                                   dpnd_freebdn,         &
+                                   dpnd_initialn,        &
+                                   dpnd_dlidn,           &
+                                   dpnd_flushn)
 
       real (kind=dbl_kind), intent(in) :: &
          dt          ! time step (s)
@@ -65,10 +67,10 @@
 
       real (kind=dbl_kind), intent(inout) :: &
          apnd, hpnd, ipnd, &
-         frpndn, &   ! pond drainage rate due to freeboard constraint (m/step)
-         rfpndn, &   ! runoff rate due to rfrac (m/step)
-         ilpndn, &   ! pond loss/gain due to ice lid (m/step)
-         flpndn      ! pond flushing rate due to ice permeability (m/s)
+         dpnd_freebdn,  & ! pond drainage rate due to freeboard constraint (m/step)
+         dpnd_initialn, & ! runoff rate due to rfrac (m/step)
+         dpnd_dlidn,    & ! pond loss/gain due to ice lid (m/step)
+         dpnd_flushn      ! pond flushing rate due to ice permeability (m/s)
 
       real (kind=dbl_kind), dimension (:), intent(in) :: &
          qicen, &  ! ice layer enthalpy (J m-3)
@@ -161,8 +163,8 @@
             ! meltwater (m3/m2) captured over entire grid cell area. 
             ! Multiply by (1-rfrac)/rfrac to get loss over entire area. 
             ! Divide by aicen to get loss per unit category area 
-            ! (for consistency with melttn, frpndn, etc)
-            rfpndn = dvn * (c1-rfrac) / (rfrac * aicen)
+            ! (for consistency with melttn, dpnd_freebdn, etc)
+            dpnd_initialn = dvn * (c1-rfrac) / (rfrac * aicen)
             dvn_temp = dvn
 
             ! shrink pond volume under freezing conditions
@@ -205,7 +207,7 @@
             volpn = volpn + dvn
             ! Track lost/gained meltwater per unit category area from pond 
             ! lid freezing/melting. Note sign flip relative to dvn convention
-            ilpndn = (dvn_temp - dvn) / aicen
+            dpnd_dlidn = (dvn_temp - dvn) / aicen
 
             !-----------------------------------------------------------
             ! update pond area and depth
@@ -235,7 +237,7 @@
             ! limit pond depth to maintain nonnegative freeboard
             hpond_tmp = hpondn
             hpondn = min(hpondn, ((rhow-rhoi)*hi - rhos*hs)/rhofresh)
-            frpndn = (hpond_tmp - hpondn) * apondn
+            dpnd_freebdn = (hpond_tmp - hpondn) * apondn
 
             ! fraction of grid cell covered by ponds
             apondn = apondn * aicen
@@ -272,7 +274,7 @@
                     + 0.5*dvn/(pndaspect*apondn), alvl_tmp*aicen))
                hpondn = c0
                if (apondn > puny) hpondn = volpn/apondn
-               flpndn = -dvn/aicen
+               dpnd_flushn = -dvn/aicen
             endif
 
          endif

--- a/columnphysics/icepack_meltpond_lvl.F90
+++ b/columnphysics/icepack_meltpond_lvl.F90
@@ -159,10 +159,10 @@
                    +                 melts*rhos &
                    +                 frain*  dt)*aicen
             endif
-            ! Track meltwater runoff fraction. Here dvn is volume of 
-            ! meltwater (m3/m2) captured over entire grid cell area. 
-            ! Multiply by (1-rfrac)/rfrac to get loss over entire area. 
-            ! Divide by aicen to get loss per unit category area 
+            ! Track meltwater runoff fraction. Here dvn is volume of
+            ! meltwater (m3/m2) captured over entire grid cell area.
+            ! Multiply by (1-rfrac)/rfrac to get loss over entire area.
+            ! Divide by aicen to get loss per unit category area
             ! (for consistency with melttn, dpnd_freebdn, etc)
             dpnd_initialn = dvn * (c1-rfrac) / (rfrac * aicen)
             dvn_temp = dvn
@@ -205,7 +205,7 @@
             endif
 
             volpn = volpn + dvn
-            ! Track lost/gained meltwater per unit category area from pond 
+            ! Track lost/gained meltwater per unit category area from pond
             ! lid freezing/melting. Note sign flip relative to dvn convention
             dpnd_dlidn = (dvn_temp - dvn) / aicen
 

--- a/columnphysics/icepack_meltpond_sealvl.F90
+++ b/columnphysics/icepack_meltpond_sealvl.F90
@@ -19,10 +19,10 @@
 ! authors David Clemens-Sewall (NCAR/NOAA)
 
       module icepack_meltpond_sealvl
-      
+
       use icepack_kinds
       use icepack_parameters, only: c0, c1, c2, c10, p01, p5, puny
-      use icepack_parameters, only: viscosity_dyn, rhoi, rhos, rhow 
+      use icepack_parameters, only: viscosity_dyn, rhoi, rhos, rhow
       use icepack_parameters, only: Timelt, Tffresh, Lfresh, rhofresh
       use icepack_parameters, only: gravit, depressT, rhofresh, kice
       use icepack_parameters, only: rhosi, use_smliq_pnd
@@ -36,7 +36,7 @@
 
       implicit none
 
-      private 
+      private
       public ::   compute_ponds_sealvl,   &
                   pond_hypsometry,        &
                   pond_height
@@ -187,7 +187,7 @@
                   hlid = max(hlid + dhlid, c0)
                   if (hs - dhs < puny) then ! pond ice is snow-free
                      ! fraction of fsurfn over pond used to melt ipond
-                     ffrac = c1 
+                     ffrac = c1
                      if (fsurfn > puny) &
                         ffrac = min(-dhlid*rhoi*Lfresh/(dt*fsurfn), c1)
                   endif
@@ -195,10 +195,10 @@
                dvpondn = dvpondn - dhlid*apnd*rhoi/rhofresh
             endif
 
-            ! Track lost/gained meltwater per unit category area from 
+            ! Track lost/gained meltwater per unit category area from
             ! pond lid freezing/melting. Note sign flip relative to dvn
             dpnd_dlidn = dvn_temp - dvpondn
-            
+
             !-----------------------------------------------------------
             ! update pond area and depth
             !-----------------------------------------------------------
@@ -223,8 +223,8 @@
             dpnd_freebdn = - dhpond * apnd
             call pond_hypsometry(hpnd, apnd, dhpond=dhpond, hin=hi)
             if (icepack_warnings_aborted(subname)) return
-            
-            ! clean up empty ponds. Note, this implies that if ponds 
+
+            ! clean up empty ponds. Note, this implies that if ponds
             ! fully drain or freeze, the lid ice also ceases to exist
             if (hpnd <= puny .or. apnd <= puny) then
                apnd = c0
@@ -249,7 +249,7 @@
                if (icepack_warnings_aborted(subname)) return
                drain = perm*pressure_head*dt/(viscosity_dyn*hi)*dpscale
                dhpond = -min(drain, hpnd)
-               dpnd_flushn = -dhpond * apnd               
+               dpnd_flushn = -dhpond * apnd
                call pond_hypsometry(hpnd, apnd, dhpond=dhpond, hin=hi)
                if (icepack_warnings_aborted(subname)) return
             endif
@@ -328,14 +328,14 @@
       real (kind=dbl_kind), intent(inout) :: &
          hpnd, &   ! pond depth of ponded area tracer
          apnd      ! pond fractional area of category tracer
-         
+
       real (kind=dbl_kind), intent(in), optional :: &
          dvpond, & ! incoming change in pond volume per category area
          dhpond, & ! incoming change in pond depth
          hin       ! category ice thickness
-      
+
       ! local variables
-      
+
       real (kind=dbl_kind) :: &
          dv, &     ! local variable for change in pond volume
          vp, &     ! local variable for pond volume per category area
@@ -364,7 +364,7 @@
             " hin needed for sealevel ponds")
          return
       endif
-      
+
       ! Get the change in volume
       if (present(dvpond)) then
          dv = dvpond
@@ -399,7 +399,7 @@
             hpnd = vp ! conserve volume
          endif
       endif
-      
+
       end subroutine pond_hypsometry
 
 !=======================================================================
@@ -412,25 +412,25 @@
             hin  , & ! category mean ice thickness
             apond , & ! pond area fraction of the category
             hpnd     ! mean pond depth (m)
-   
+
          real (kind=dbl_kind), intent(out) :: &
             hpsurf   ! height of pond surface above base of the ice (m)
 
          ! local variables
          real (kind=dbl_kind) :: &
             pndasp   ! pond aspect ratio
-         
+
          character(len=*),parameter :: subname='(pond_height)'
-   
+
          if (trim(pndhead) == 'perched') then
             hpsurf = hin + hpnd
          elseif (trim(pndhead) == 'hyps') then
             if ((trim(pndhyps) == 'fixed') .or. &
                (trim(pndhyps) == 'sealevel')) then
-               ! Applying a fixed aspect ratio to the ponds implicitly 
+               ! Applying a fixed aspect ratio to the ponds implicitly
                ! assumes that the hypsometric curve has a constant slope
                ! of double the aspect ratio.
-               ! If ponds occupy lowest elevations first. 
+               ! If ponds occupy lowest elevations first.
                if (trim(pndhyps) == 'sealevel') then
                   pndasp = calc_pndasp(hin)
                else
@@ -453,7 +453,7 @@
             call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
             if (icepack_warnings_aborted(subname)) return
          endif
-   
+
       end subroutine pond_height
 
 !=======================================================================

--- a/columnphysics/icepack_meltpond_sealvl.F90
+++ b/columnphysics/icepack_meltpond_sealvl.F90
@@ -54,8 +54,9 @@
                                        aicen,  vicen,  vsnon, &
                                        qicen,  sicen,         &
                                        apnd,   hpnd,  ipnd,   &
-                                       meltsliqn, frpndn,     &
-                                       ilpndn, flpndn)
+                                       meltsliqn,             &
+                                       dpnd_freebdn,          &
+                                       dpnd_dlidn, dpnd_flushn)
 
       real (kind=dbl_kind), intent(in) :: &
          dt          ! time step (s)
@@ -74,9 +75,9 @@
 
       real (kind=dbl_kind), intent(inout) :: &
          apnd, hpnd, ipnd, & ! pond tracers
-         frpndn, &   ! pond drainage rate due to freeboard constraint (m/step)
-         ilpndn, &   ! pond loss/gain due to ice lid (m/step)
-         flpndn      ! pond flushing rate due to ice permeability (m/s)
+         dpnd_freebdn,     & ! pond drainage rate due to freeboard constraint (m/step)
+         dpnd_dlidn,       & ! pond loss/gain due to ice lid (m/step)
+         dpnd_flushn         ! pond flushing rate due to ice permeability (m/s)
 
       real (kind=dbl_kind), dimension (:), intent(in) :: &
          qicen, &    ! ice layer enthalpy (J m-3)
@@ -138,7 +139,7 @@
             !-----------------------------------------------------------
             ! Remove ponds on thin ice
             !-----------------------------------------------------------
-            frpndn = vpondn
+            dpnd_freebdn = vpondn
             apnd = c0
             hpnd = c0
             vpondn = c0
@@ -196,7 +197,7 @@
 
             ! Track lost/gained meltwater per unit category area from 
             ! pond lid freezing/melting. Note sign flip relative to dvn
-            ilpndn = dvn_temp - dvpondn
+            dpnd_dlidn = dvn_temp - dvpondn
             
             !-----------------------------------------------------------
             ! update pond area and depth
@@ -219,7 +220,7 @@
                if (icepack_warnings_aborted(subname)) return
             endif
             dhpond = min(dhpond, c0) ! strictly drainage
-            frpndn = - dhpond * apnd
+            dpnd_freebdn = - dhpond * apnd
             call pond_hypsometry(hpnd, apnd, dhpond=dhpond, hin=hi)
             if (icepack_warnings_aborted(subname)) return
             
@@ -248,7 +249,7 @@
                if (icepack_warnings_aborted(subname)) return
                drain = perm*pressure_head*dt/(viscosity_dyn*hi)*dpscale
                dhpond = -min(drain, hpnd)
-               flpndn = -dhpond * apnd               
+               dpnd_flushn = -dhpond * apnd               
                call pond_hypsometry(hpnd, apnd, dhpond=dhpond, hin=hi)
                if (icepack_warnings_aborted(subname)) return
             endif

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -713,7 +713,7 @@
          calc_Tsfc_in    , &! if true, calculate surface temperature
                             ! if false, Tsfc is computed elsewhere and
                             ! atmos-ice fluxes are provided to CICE
-         semi_implicit_Tsfc_in   , &! compute dfsurf/dT, dflat/dT terms instead of fsurf, flat 
+         semi_implicit_Tsfc_in   , &! compute dfsurf/dT, dflat/dT terms instead of fsurf, flat
          vapor_flux_correction_in, &! compute mass/enthalpy correction when evaporation/sublimation
                             ! computed outside at 0C
          update_ocn_f_in    ! include fresh water and salt fluxes for frazil
@@ -1085,7 +1085,7 @@
          windmin_in, &      ! minimum wind speed to compact snow (m/s)
          drhosdwind_in, &   ! wind compaction factor (kg s/m^4)
          snwlvlfac_in, &    ! fractional increase in snow depth
-         snw_growth_wet_in, & ! wet metamorphism parameter (um^3/s)
+         snw_growth_wet_in,&! wet metamorphism parameter (um^3/s)
          drsnw_min_in, &    ! minimum snow grain growth factor
          snwliq_max_in      ! irreducible saturation fraction
 
@@ -1729,7 +1729,7 @@
          calc_Tsfc_out    ,&! if true, calculate surface temperature
                             ! if false, Tsfc is computed elsewhere and
                             ! atmos-ice fluxes are provided to CICE
-         semi_implicit_Tsfc_out    ,&! compute dfsurf/dT, dflat/dT terms instead of fsurf, flat 
+         semi_implicit_Tsfc_out    ,&! compute dfsurf/dT, dflat/dT terms instead of fsurf, flat
          vapor_flux_correction_out ,&! compute mass/enthalpy correction when evaporation/sublimation
                             ! computed outside at 0C
          update_ocn_f_out   ! include fresh water and salt fluxes for frazil
@@ -2103,7 +2103,7 @@
          windmin_out, &      ! minimum wind speed to compact snow (m/s)
          drhosdwind_out, &   ! wind compaction factor (kg s/m^4)
          snwlvlfac_out,  &   ! fractional increase in snow depth
-         snw_growth_wet_out, & ! wet metamorphism parameter (um^3/s)
+         snw_growth_wet_out,&! wet metamorphism parameter (um^3/s)
          drsnw_min_out, &    ! minimum snow grain growth factor
          snwliq_max_out      ! irreducible saturation fraction
 

--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -3531,7 +3531,7 @@
 
       logical (kind=log_kind), intent(in) :: &
          l_initonly  ! local initonly value
-      
+
       ! local variables
       real (kind=dbl_kind) :: &
          hsnlvl  , & ! snow depth over level ice (m)

--- a/columnphysics/icepack_snow.F90
+++ b/columnphysics/icepack_snow.F90
@@ -32,7 +32,7 @@
       public :: icepack_step_snow, drain_snow, icepack_init_snow
 
       real (kind=dbl_kind), parameter, public :: &
-         drsnw_min_o = 1.0186_dbl_kind    ! Bun 1989  (um^3/s)  
+         drsnw_min_o = 1.0186_dbl_kind    ! Bun 1989  (um^3/s)
                                           ! minimum volume growth rate 1.28x10^-8 mm^3/s/4/pi
 
       real (kind=dbl_kind) :: &

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -99,7 +99,7 @@
                              vicen,       vsnon,       &
                              aice,        aice0,       &
                              fpond,       Tf,          &
-                             mipnd)
+                             dpnd_melt)
 
       real (kind=dbl_kind), dimension(0:ncat), intent(in) :: &
          hin_max      ! category boundaries (m)
@@ -136,7 +136,7 @@
          fpond     ! fresh water flux to ponds (kg/m^2/s)
 
       real (kind=dbl_kind), intent(inout), optional :: &
-         mipnd     ! pond 'drainage' due to ice melting (m / step)
+         dpnd_melt ! pond 'drainage' due to ice melting (m / step)
 
       ! local variables
 
@@ -467,12 +467,12 @@
                   if (tr_pond_topo) &
                      fpond = fpond - (da0 * trcrn(nt_apnd,1) &
                                           * trcrn(nt_hpnd,1))
-                  if (tr_pond .and. present(mipnd)) then
+                  if (tr_pond .and. present(dpnd_melt)) then
                      if (tr_pond_lvl) then
-                        mipnd = mipnd + da0 * trcrn(nt_apnd,1)  & 
+                        dpnd_melt = dpnd_melt + da0 * trcrn(nt_apnd,1)  & 
                                  * trcrn(nt_hpnd,1) * trcrn(nt_alvl,1)
                      else
-                        mipnd = mipnd + da0*trcrn(nt_apnd,1)*trcrn(nt_hpnd,1)
+                        dpnd_melt = dpnd_melt + da0*trcrn(nt_apnd,1)*trcrn(nt_hpnd,1)
                      endif
                   endif
 
@@ -890,7 +890,7 @@
                                aicen,      vicen,      &
                                vsnon,      trcrn,      &
                                flux_bio,   d_afsd_latm,&
-                               mipnd)
+                               dpnd_melt)
 
       real (kind=dbl_kind), intent(in) :: &
          dt        ! time step (s)
@@ -917,7 +917,7 @@
          meltl         ! lateral ice melt         (m/step-->cm/day)
 
       real (kind=dbl_kind), intent(inout), optional :: &
-         mipnd         ! pond 'drainage' due to ice melting (m / step)
+         dpnd_melt     ! pond 'drainage' due to ice melting (m / step)
 
       real (kind=dbl_kind), dimension(nbtrcr), intent(inout) :: &
          flux_bio  ! biology tracer flux from layer bgc (mmol/m^2/s)
@@ -1029,12 +1029,12 @@
             fpond  = fpond - dfpond
          endif
 
-            if (tr_pond .and. present(mipnd)) then
+            if (tr_pond .and. present(dpnd_melt)) then
                if (tr_pond_lvl) then
-                  mipnd = mipnd + aicen(n)*trcrn(nt_apnd,n)*trcrn(nt_hpnd,n) &
+                  dpnd_melt = dpnd_melt + aicen(n)*trcrn(nt_apnd,n)*trcrn(nt_hpnd,n) &
                            *rsiden(n)*trcrn(nt_alvl,n)
                else
-                  mipnd = mipnd + aicen(n)*trcrn(nt_apnd,n)*trcrn(nt_hpnd,n) &
+                  dpnd_melt = dpnd_melt + aicen(n)*trcrn(nt_apnd,n)*trcrn(nt_hpnd,n) &
                            *rsiden(n)
                endif
             endif
@@ -1898,7 +1898,7 @@
                                      dwavefreq,                   &
                                      d_afsd_latg,  d_afsd_newi,   &
                                      d_afsd_latm,  d_afsd_weld,   &
-                                     mipnd)
+                                     dpnd_melt)
 
       use icepack_parameters, only: icepack_init_parameters
 
@@ -1943,7 +1943,7 @@
          frazil_diag  ! frazil ice growth diagnostic (m/step-->cm/day)
 
       real (kind=dbl_kind), intent(inout), optional :: &
-         mipnd        ! pond 'drainage' due to ice melting (m / step)
+         dpnd_melt    ! pond 'drainage' due to ice melting (m / step)
 
       real (kind=dbl_kind), intent(in), optional :: &
          wlat         ! lateral melt rate (m/s)
@@ -2083,7 +2083,7 @@
                              aice      ,         &
                              aice0     ,         &
                              fpond, Tf ,         &
-                             mipnd)
+                             dpnd_melt)
             if (icepack_warnings_aborted(subname)) return
 
          endif ! aice > puny
@@ -2134,7 +2134,7 @@
                          aicen,     vicen,         &
                          vsnon,     trcrn,         &
                          flux_bio,                 &
-                         d_afsd_latm, mipnd)
+                         d_afsd_latm, dpnd_melt)
       if (icepack_warnings_aborted(subname)) return
 
       ! Floe welding during freezing conditions
@@ -2155,7 +2155,7 @@
          call reduce_area (hin_max   (0),                &
                            aicen     (1), vicen     (1), &
                            aicen_init(1), vicen_init(1), &
-                           mipnd,         trcrn)
+                           dpnd_melt    , trcrn)
          if (icepack_warnings_aborted(subname)) return
 
       !-----------------------------------------------------------------

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -469,7 +469,7 @@
                                           * trcrn(nt_hpnd,1))
                   if (tr_pond .and. present(dpnd_melt)) then
                      if (tr_pond_lvl) then
-                        dpnd_melt = dpnd_melt + da0 * trcrn(nt_apnd,1)  & 
+                        dpnd_melt = dpnd_melt + da0 * trcrn(nt_apnd,1)  &
                                  * trcrn(nt_hpnd,1) * trcrn(nt_alvl,1)
                      else
                         dpnd_melt = dpnd_melt + da0*trcrn(nt_apnd,1)*trcrn(nt_hpnd,1)

--- a/columnphysics/icepack_therm_mushy.F90
+++ b/columnphysics/icepack_therm_mushy.F90
@@ -116,7 +116,7 @@
          zSin        , & ! internal ice layer salinities
          zqsn        , & ! snow layer enthalpy (J m-3)
          zTsn            ! internal snow layer temperatures
-     
+
      real (kind=dbl_kind), intent(inout):: &
          dpnd_flush  , & ! pond flushing rate due to ice permeability (m/s)
          dpnd_expon      ! exponential pond drainage rate (m/s)
@@ -3238,7 +3238,7 @@
          apond     , & ! melt pond area fraction of category (-)
          dpnd_flush, & ! pond flushing rate due to ice permeability (m/s)
          dpnd_expon    ! exponential pond drainage rate (m/s)
-     
+
     real(kind=dbl_kind) :: &
          dhpond   , & ! change in pond depth per unit pond area (m)
          ice_mass , & ! mass of ice (kg m-2)
@@ -3270,7 +3270,7 @@
           endif
           hpond = max(hpond, c0)
 
-          !-------------------------------------------------------------          
+          !-------------------------------------------------------------
           ! exponential decay of pond (macro-flaw drainage)
           !-------------------------------------------------------------
           lambda_pond = c1 / (tscale_pnd_drain*24.0_dbl_kind &
@@ -3278,7 +3278,7 @@
           if (trim(pndmacr) == 'lambda') then
                dhpond = max(-lambda_pond*dt*(hpond + hpond0),-hpond)
           elseif (trim(pndmacr) == 'head') then
-               ! Calling calc_ice_mass here is not bit-for-bit due to optimization, so left inline for now. 
+               ! Calling calc_ice_mass here is not bit-for-bit due to optimization, so left inline for now.
                ! This will be updated in the future.
                call calc_ice_mass(phi, zTin, hilyr, ice_mass)
                if (icepack_warnings_aborted(subname)) return
@@ -3681,7 +3681,7 @@
 !=======================================================================
 
   subroutine calc_ice_mass(phi, zTin, hilyr, ice_mass)
-     
+
      ! Calculate the mass of the ice per unit category area
      real(kind=dbl_kind), dimension(:), intent(in) :: &
           zTin      , & ! ice layer temperature (C)
@@ -3692,11 +3692,11 @@
 
      real(kind=dbl_kind), intent(out) :: &
           ice_mass      ! mass per unit category area (kg m-2)
-     
+
      ! local variables
      integer(kind=int_kind) :: &
           k             ! ice layer index
-     
+
      character(len=*),parameter :: subname='(calc_ice_mass)'
 
      ice_mass = c0

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -2609,8 +2609,24 @@
             call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
             return
          endif
-         if ((present(dsnow) .and. .not.present(dsnown)) .or. &
-             (present(dsnown) .and. .not.present(dsnow))) then
+         if (tr_pond) then
+            if ((present(flpndn) .and. .not.present(flpnd )) .or. &
+                (present(flpnd ) .and. .not.present(flpndn)) .or. &
+                (present(expndn) .and. .not.present(expnd )) .or. &
+                (present(expnd ) .and. .not.present(expndn)) .or. &
+                (present(frpndn) .and. .not.present(frpnd )) .or. &
+                (present(frpnd ) .and. .not.present(frpndn)) .or. &
+                (present(rfpndn) .and. .not.present(rfpnd )) .or. &
+                (present(rfpnd ) .and. .not.present(rfpndn)) .or. &
+                (present(ilpndn) .and. .not.present(ilpnd )) .or. &
+                (present(ilpnd ) .and. .not.present(ilpndn))) then
+               call icepack_warnings_add(subname//' error in pond arguments')
+               call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
+               return
+            endif
+         endif
+         if ((present(dsnow ) .and. .not.present(dsnown)) .or. &
+             (present(dsnown) .and. .not.present(dsnow ))) then
             call icepack_warnings_add(subname//' error in dsnow arguments')
             call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
             return
@@ -2736,13 +2752,12 @@
          l_frpndn = c0
          l_rfpndn = c0
          l_ilpndn = c0
-         if (tr_pond .and. present(flpndn) .and. present(expndn) .and. &
-             present(frpndn) .and. present(rfpndn) .and. present(ilpndn)) then
-            l_flpndn = flpndn (n)
-            l_expndn = expndn (n) 
-            l_frpndn = frpndn (n)
-            l_rfpndn = rfpndn (n)
-            l_ilpndn = ilpndn (n)
+         if (tr_pond) then
+            if (present(flpndn)) l_flpndn = flpndn(n)
+            if (present(expndn)) l_expndn = expndn(n)
+            if (present(frpndn)) l_frpndn = frpndn(n)
+            if (present(rfpndn)) l_rfpndn = rfpndn(n)
+            if (present(ilpndn)) l_ilpndn = ilpndn(n)
          endif
          l_dsnown   = c0
 
@@ -3144,7 +3159,12 @@
 
          endif
 
-         if (present(dsnown      )) dsnown(n)    = l_dsnown
+         if (present(dsnown)) dsnown(n) = l_dsnown
+         if (present(flpndn)) flpndn(n) = l_flpndn
+         if (present(expndn)) expndn(n) = l_expndn
+         if (present(frpndn)) frpndn(n) = l_frpndn
+         if (present(rfpndn)) rfpndn(n) = l_rfpndn
+         if (present(ilpndn)) ilpndn(n) = l_ilpndn
 
       enddo                  ! ncat
 

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -111,7 +111,7 @@
                                   mlt_onset,   frz_onset, &
                                   yday,        dsnow,     &
                                   prescribed_ice,         &
-                                  flpnd,       expnd)
+                                  dpnd_flush,  dpnd_expon)
 
       real (kind=dbl_kind), intent(in) :: &
          dt      , & ! time step
@@ -204,8 +204,8 @@
          dsnow    , & ! change in snow thickness (m/step-->cm/day)
          mlt_onset, & ! day of year that sfc melting begins
          frz_onset, & ! day of year that freezing begins (congel or frazil)
-         flpnd    , & ! pond flushing rate due to ice permeability (m/s)
-         expnd        ! exponential pond drainage rate (m/s)
+         dpnd_flush,& ! pond flushing rate due to ice permeability (m/s)
+         dpnd_expon   ! exponential pond drainage rate (m/s)
 
       real (kind=dbl_kind), intent(in) :: &
          yday         ! day of year
@@ -273,12 +273,12 @@
       massice(:) = c0
       massliq(:) = c0
       if (tr_pond) then
-         flpnd   = c0
-         expnd   = c0
+         dpnd_flush = c0
+         dpnd_expon = c0
       endif
 
       if (calc_Tsfc) then
-         fsensn  = c0
+         fsensn    = c0
          flatn     = c0
          fsurfn    = c0
          fcondtopn = c0
@@ -335,7 +335,7 @@
                                               fcondtopn, fcondbotn, &
                                               fadvocn,   snoice,    &
                                               smice,     smliq,     &
-                                              flpnd,     expnd)
+                                              dpnd_flush,dpnd_expon)
             if (icepack_warnings_aborted(subname)) return
 
          else ! ktherm
@@ -2265,11 +2265,11 @@
                                     mlt_onset   , frz_onset   , &
                                     yday        , prescribed_ice, &
                                     zlvs        , afsdn       , &
-                                    flpnd       , flpndn      , &
-                                    expnd       , expndn      , &
-                                    frpnd       , frpndn      , &
-                                    rfpnd       , rfpndn      , &
-                                    ilpnd       , ilpndn)
+                                    dpnd_flush  , dpnd_flushn , &
+                                    dpnd_expon  , dpnd_exponn , &
+                                    dpnd_freebd , dpnd_freebdn, &
+                                    dpnd_initial, dpnd_initialn, &
+                                    dpnd_dlid   , dpnd_dlidn)
 
       real (kind=dbl_kind), intent(in) :: &
          dt          , & ! time step
@@ -2357,11 +2357,11 @@
          frz_onset       ! day of year that freezing begins (congel or frazil)
 
       real (kind=dbl_kind), intent(inout), optional :: &
-         flpnd       , & ! pond flushing rate due to ice permeability (m/step)
-         expnd       , & ! exponential pond drainage rate (m/step)
-         frpnd       , & ! pond drainage rate due freeboard constraint (m/step)
-         rfpnd       , & ! runoff rate due to rfrac (m/step)
-         ilpnd           ! pond loss/gain (+/-) to ice lid (m/step)
+         dpnd_flush  , & ! pond flushing rate due to ice permeability (m/step)
+         dpnd_expon  , & ! exponential pond drainage rate (m/step)
+         dpnd_freebd , & ! pond drainage rate due freeboard constraint (m/step)
+         dpnd_initial, & ! runoff rate due to rfrac (m/step)
+         dpnd_dlid       ! pond loss/gain (+/-) to ice lid (m/step)
 
       real (kind=dbl_kind), intent(out), optional :: &
          wlat            ! lateral melt rate (m/s)
@@ -2443,11 +2443,11 @@
          snoicen         ! snow-ice growth                        (m)
 
       real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
-         flpndn      , & ! category pond flushing rate          (m/step)
-         expndn      , & ! exponential pond drainage rate       (m/step)
-         frpndn      , & ! pond drainage rate due to freeboard  (m/step)
-         rfpndn      , & ! runoff rate due to rfrac (m/step)
-         ilpndn          ! category pond loss/gain due to ice lid (m/step)
+         dpnd_flushn , & ! category pond flushing rate          (m/step)
+         dpnd_exponn , & ! exponential pond drainage rate       (m/step)
+         dpnd_freebdn, & ! pond drainage rate due to freeboard  (m/step)
+         dpnd_initialn,& ! runoff rate due to rfrac (m/step)
+         dpnd_dlidn      ! category pond loss/gain due to ice lid (m/step)
 
       real (kind=dbl_kind), dimension(:), intent(in) :: &
          fswthrun        ! SW through ice to ocean            (W/m^2)
@@ -2546,11 +2546,11 @@
          l_meltsliq        ! mass of snow melt local           (kg/m^2)
 
       real (kind=dbl_kind) :: &
-         l_flpndn      , & ! category pond flushing rate          (m/step)
-         l_expndn      , & ! exponential pond drainage rate       (m/step)
-         l_frpndn      , & ! pond drainage rate due to freeboard  (m/step)
-         l_rfpndn      , & ! runoff rate due to rfrac (m/step)
-         l_ilpndn          ! category pond loss/gain due to ice lid (m/step)
+         l_dpnd_flushn,  & ! category pond flushing rate          (m/step)
+         l_dpnd_exponn,  & ! exponential pond drainage rate       (m/step)
+         l_dpnd_freebdn, & ! pond drainage rate due to freeboard  (m/step)
+         l_dpnd_initialn,& ! runoff rate due to rfrac (m/step)
+         l_dpnd_dlidn      ! category pond loss/gain due to ice lid (m/step)
 
       real (kind=dbl_kind) :: &
          pond            ! water retained in ponds                (m)
@@ -2610,16 +2610,16 @@
             return
          endif
          if (tr_pond) then
-            if ((present(flpndn) .and. .not.present(flpnd )) .or. &
-                (present(flpnd ) .and. .not.present(flpndn)) .or. &
-                (present(expndn) .and. .not.present(expnd )) .or. &
-                (present(expnd ) .and. .not.present(expndn)) .or. &
-                (present(frpndn) .and. .not.present(frpnd )) .or. &
-                (present(frpnd ) .and. .not.present(frpndn)) .or. &
-                (present(rfpndn) .and. .not.present(rfpnd )) .or. &
-                (present(rfpnd ) .and. .not.present(rfpndn)) .or. &
-                (present(ilpndn) .and. .not.present(ilpnd )) .or. &
-                (present(ilpnd ) .and. .not.present(ilpndn))) then
+            if ((present(dpnd_flushn  ) .and. .not.present(dpnd_flush   )) .or. &
+                (present(dpnd_flush   ) .and. .not.present(dpnd_flushn  )) .or. &
+                (present(dpnd_exponn  ) .and. .not.present(dpnd_expon   )) .or. &
+                (present(dpnd_expon   ) .and. .not.present(dpnd_exponn  )) .or. &
+                (present(dpnd_freebdn ) .and. .not.present(dpnd_freebd  )) .or. &
+                (present(dpnd_freebd  ) .and. .not.present(dpnd_freebdn )) .or. &
+                (present(dpnd_initialn) .and. .not.present(dpnd_initial )) .or. &
+                (present(dpnd_initial ) .and. .not.present(dpnd_initialn)) .or. &
+                (present(dpnd_dlidn   ) .and. .not.present(dpnd_dlid    )) .or. &
+                (present(dpnd_dlid    ) .and. .not.present(dpnd_dlidn   ))) then
                call icepack_warnings_add(subname//' error in pond arguments')
                call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
                return
@@ -2747,17 +2747,17 @@
          meltbn (n) = c0
          congeln(n) = c0
          snoicen(n) = c0
-         l_flpndn = c0
-         l_expndn = c0
-         l_frpndn = c0
-         l_rfpndn = c0
-         l_ilpndn = c0
+         l_dpnd_flushn   = c0
+         l_dpnd_exponn   = c0
+         l_dpnd_freebdn  = c0
+         l_dpnd_initialn = c0
+         l_dpnd_dlidn    = c0
          if (tr_pond) then
-            if (present(flpndn)) l_flpndn = flpndn(n)
-            if (present(expndn)) l_expndn = expndn(n)
-            if (present(frpndn)) l_frpndn = frpndn(n)
-            if (present(rfpndn)) l_rfpndn = rfpndn(n)
-            if (present(ilpndn)) l_ilpndn = ilpndn(n)
+            if (present(dpnd_flushn)  ) l_dpnd_flushn   = dpnd_flushn(n)
+            if (present(dpnd_exponn)  ) l_dpnd_exponn   = dpnd_exponn(n)
+            if (present(dpnd_freebdn) ) l_dpnd_freebdn  = dpnd_freebdn(n)
+            if (present(dpnd_initialn)) l_dpnd_initialn = dpnd_initialn(n)
+            if (present(dpnd_dlidn)   ) l_dpnd_dlidn    = dpnd_dlidn(n)
          endif
          l_dsnown   = c0
 
@@ -2896,7 +2896,8 @@
                                  mlt_onset=mlt_onset, frz_onset=frz_onset,     &
                                  yday=yday,           dsnow=l_dsnown         , &
                                  prescribed_ice=prescribed_ice,                &
-                                 flpnd=l_flpndn     , expnd=l_expndn )
+                                 dpnd_flush=l_dpnd_flushn,                     &
+                                 dpnd_expon=l_dpnd_exponn )
 
             if (icepack_warnings_aborted(subname)) then
                write(warnstr,*) subname, ' ice: Vertical thermo error, cat ', n
@@ -3009,15 +3010,15 @@
                                        apnd=apnd    (n), &
                                        hpnd=hpnd    (n), &
                                        ipnd=ipnd    (n), &
-                                       meltsliqn=l_meltsliqn(n), &
-                                       frpndn=l_frpndn, &
-                                       rfpndn=l_rfpndn, &
-                                       ilpndn=l_ilpndn, &
-                                       flpndn=l_flpndn)
+                                       meltsliqn     = l_meltsliqn(n), &
+                                       dpnd_freebdn  = l_dpnd_freebdn, &
+                                       dpnd_initialn = l_dpnd_initialn,&
+                                       dpnd_dlidn    = l_dpnd_dlidn,   &
+                                       dpnd_flushn   = l_dpnd_flushn)
                if (icepack_warnings_aborted(subname)) return
 
             elseif (tr_pond_sealvl) then
-               call compute_ponds_sealvl(dt=dt,           &
+               call compute_ponds_sealvl(dt=dt,          &
                                        meltt=melttn (n), &
                                        melts=meltsn (n), &
                                        frain=frain,      &
@@ -3034,10 +3035,10 @@
                                        apnd=apnd    (n), &
                                        hpnd=hpnd    (n), &
                                        ipnd=ipnd    (n), &
-                                       meltsliqn=l_meltsliqn(n), &
-                                       frpndn=l_frpndn, &
-                                       ilpndn=l_ilpndn, &
-                                       flpndn=l_flpndn)
+                                       meltsliqn    = l_meltsliqn(n), &
+                                       dpnd_freebdn = l_dpnd_freebdn, &
+                                       dpnd_dlidn   = l_dpnd_dlidn,   &
+                                       dpnd_flushn  = l_dpnd_flushn)
                if (icepack_warnings_aborted(subname)) return
 
             elseif (tr_pond_topo) then
@@ -3149,22 +3150,27 @@
                                fiso_ocnn=fiso_ocnn,                 &
                                fiso_evap=fiso_evap,                 &
                                fiso_evapn=fiso_evapn,               &
-                               flpnd=flpnd,       flpndn=l_flpndn, &
-                               expnd=expnd,       expndn=l_expndn, &
-                               frpnd=frpnd,       frpndn=l_frpndn, &
-                               rfpnd=rfpnd,       rfpndn=l_rfpndn, &
-                               ilpnd=ilpnd,       ilpndn=l_ilpndn)
+                               dpnd_flush=dpnd_flush,               &
+                               dpnd_flushn=l_dpnd_flushn,           &
+                               dpnd_expon=dpnd_expon,               &
+                               dpnd_exponn=l_dpnd_exponn,           &
+                               dpnd_freebd=dpnd_freebd,             &
+                               dpnd_freebdn=l_dpnd_freebdn,         &
+                               dpnd_initial=dpnd_initial,           &
+                               dpnd_initialn=l_dpnd_initialn,       &
+                               dpnd_dlid=dpnd_dlid,                 &
+                               dpnd_dlidn=l_dpnd_dlidn)
 
             if (icepack_warnings_aborted(subname)) return
 
          endif
 
-         if (present(dsnown)) dsnown(n) = l_dsnown
-         if (present(flpndn)) flpndn(n) = l_flpndn
-         if (present(expndn)) expndn(n) = l_expndn
-         if (present(frpndn)) frpndn(n) = l_frpndn
-         if (present(rfpndn)) rfpndn(n) = l_rfpndn
-         if (present(ilpndn)) ilpndn(n) = l_ilpndn
+         if (present(dsnown)       ) dsnown       (n) = l_dsnown
+         if (present(dpnd_flushn)  ) dpnd_flushn  (n) = l_dpnd_flushn
+         if (present(dpnd_exponn)  ) dpnd_exponn  (n) = l_dpnd_exponn
+         if (present(dpnd_freebdn) ) dpnd_freebdn (n) = l_dpnd_freebdn
+         if (present(dpnd_initialn)) dpnd_initialn(n) = l_dpnd_initialn
+         if (present(dpnd_dlidn)   ) dpnd_dlidn   (n) = l_dpnd_dlidn
 
       enddo                  ! ncat
 

--- a/columnphysics/icepack_tracers.F90
+++ b/columnphysics/icepack_tracers.F90
@@ -105,7 +105,7 @@
          tr_pond      = .false., & ! if .true., use melt pond tracer
          tr_pond_lvl  = .false., & ! if .true., use level-ice pond tracer
          tr_pond_topo = .false., & ! if .true., use explicit topography-based ponds
-         tr_pond_sealvl = .false., & ! if .true., use sealvl pond parameterization
+         tr_pond_sealvl=.false., & ! if .true., use sealvl pond parameterization
          tr_snow      = .false., & ! if .true., use snow redistribution or metamorphosis tracers
          tr_iso       = .false., & ! if .true., use isotope tracers
          tr_aero      = .false., & ! if .true., use aerosol tracers
@@ -220,7 +220,7 @@
              tr_pond_in      , & ! if .true., use melt pond tracer
              tr_pond_lvl_in  , & ! if .true., use level-ice pond tracer
              tr_pond_topo_in , & ! if .true., use explicit topography-based ponds
-             tr_pond_sealvl_in , & ! if .true., use sealvl pond parameteriztion
+             tr_pond_sealvl_in,& ! if .true., use sealvl pond parameteriztion
              tr_snow_in      , & ! if .true., use snow redistribution or metamorphosis tracers
              tr_fsd_in       , & ! if .true., use floe size distribution tracers
              tr_iso_in       , & ! if .true., use isotope tracers
@@ -312,7 +312,7 @@
              tr_pond_out      , & ! if .true., use melt pond tracer
              tr_pond_lvl_out  , & ! if .true., use level-ice pond tracer
              tr_pond_topo_out , & ! if .true., use explicit topography-based ponds
-             tr_pond_sealvl_out, & ! if .true., use sealvl pond parameterization
+             tr_pond_sealvl_out,& ! if .true., use sealvl pond parameterization
              tr_snow_out      , & ! if .true., use snow redistribution or metamorphosis tracers
              tr_fsd_out       , & ! if .true., use floe size distribution
              tr_iso_out       , & ! if .true., use isotope tracers

--- a/configuration/driver/icedrv_flux.F90
+++ b/configuration/driver/icedrv_flux.F90
@@ -268,20 +268,20 @@
       real (kind=dbl_kind), &
          dimension (nx,ncat), public :: &
          ! Like melttn these are defined as volume per unit category area
-         flpndn,   & ! category pond flushing rate due to ice permeability
-         expndn,   & ! category exponential pond drainage rate
-         frpndn,   & ! category pond drainage rate due to freeboard constraint
-         rfpndn,   & ! category runoff rate due to rfrac (m/step)
-         ilpndn      ! category pond loss/gain due to ice lid (m/step)
+         dpnd_flushn,   & ! category pond flushing rate due to ice permeability
+         dpnd_exponn,   & ! category exponential pond drainage rate
+         dpnd_freebdn,  & ! category pond drainage rate due to freeboard constraint
+         dpnd_initialn, & ! category runoff rate due to rfrac (m/step)
+         dpnd_dlidn       ! category pond loss/gain due to ice lid (m/step)
 
       real (kind=dbl_kind), dimension (nx), public :: &
-         flpnd,  & ! pond flushing rate due to ice permeability (m/step)
-         expnd,  & ! exponential pond drainage rate (m/step)
-         frpnd,  & ! pond drainage rate due to freeboard constraint (m/step)
-         rfpnd,  & ! runoff rate due to rfrac (m/step)
-         ilpnd,  & ! pond loss/gain (+/-) to ice lid freezing/melting (m/step)
-         mipnd,  & ! pond 'drainage' due to ice melting (m / step)
-         rdpnd     ! pond drainage due to ridging (m / step)
+         dpnd_flush,    & ! pond flushing rate due to ice permeability (m/step)
+         dpnd_expon,    & ! exponential pond drainage rate (m/step)
+         dpnd_freebd,   & ! pond drainage rate due to freeboard constraint (m/step)
+         dpnd_initial,  & ! runoff rate due to rfrac (m/step)
+         dpnd_dlid,     & ! pond loss/gain (+/-) to ice lid freezing/melting (m/step)
+         dpnd_melt,     & ! pond 'drainage' due to ice melting (m / step)
+         dpnd_ridge       ! pond drainage due to ridging (m / step)
 
       ! As above but these remain grid box mean values i.e. they are not
       ! divided by aice at end of ice_dynamics.
@@ -716,13 +716,13 @@
       apeff_ai (:) = c0
       snowfrac (:) = c0
       frazil_diag (:) = c0
-      flpnd (:) = c0
-      expnd (:) = c0
-      frpnd (:) = c0
-      rfpnd (:) = c0
-      ilpnd (:) = c0
-      mipnd (:) = c0
-      rdpnd (:) = c0
+      dpnd_flush  (:) = c0
+      dpnd_expon  (:) = c0
+      dpnd_freebd (:) = c0
+      dpnd_initial(:) = c0
+      dpnd_dlid   (:) = c0
+      dpnd_melt   (:) = c0
+      dpnd_ridge  (:) = c0
 
       ! drag coefficients are computed prior to the atmo_boundary call,
       ! during the thermodynamics section

--- a/configuration/driver/icedrv_history.F90
+++ b/configuration/driver/icedrv_history.F90
@@ -98,7 +98,7 @@
             'dsnow           ', 'congel          ', 'sst             ', &
             'sss             ', 'Tf              ', 'fhocn           ', &
             'melts           ' /)
-            
+
       integer (kind=dbl_kind), parameter :: num_2d_pond = 10
       character(len=16), parameter :: fld_2d_pond(num_2d_pond) = &
          (/ 'apnd            ', 'hpnd            ', 'ipnd            ', &
@@ -118,7 +118,7 @@
       character(len=16), parameter :: fld_3d_nfsd(num_3d_nfsd) = &
          (/ 'd_afsd_newi     ', 'd_afsd_latg     ', 'd_afsd_latm     ', &
             'd_afsd_wave     ', 'd_afsd_weld     ' /)
-      
+
       integer (kind=dbl_kind), parameter :: num_3d_pond = 8
       character(len=16), parameter :: fld_3d_pond(num_3d_pond) = &
          (/ 'apndn           ', 'hpndn           ', 'ipndn           ', &
@@ -242,7 +242,7 @@
                if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR in def_var '//trim(fld_3d_pond(n)))
             enddo
          endif ! tr_pnd
-   
+
          if (tr_fsd) then
             ! 3d nfsd fields
 

--- a/configuration/driver/icedrv_history.F90
+++ b/configuration/driver/icedrv_history.F90
@@ -74,6 +74,7 @@
          varid, &                        ! cdf varid
          status, &                       ! cdf status flag
          iflag, &                        ! history file attributes
+         numvars, &                      ! temporary for writing fields
          nt_apnd, nt_hpnd, nt_ipnd       ! pond tracer indices
 
       character (len=8) :: &
@@ -112,7 +113,8 @@
 
       logical (kind=log_kind) :: &
          tr_fsd, &                        ! flag for tracing fsd
-         tr_pnd                           ! flag for tracing ponds
+         tr_pnd, &                        ! flag for tracing ponds
+         tr_pnd_topo                      ! flag for tracing topo ponds
 
       integer (kind=dbl_kind), parameter :: num_3d_nfsd = 5
       character(len=16), parameter :: fld_3d_nfsd(num_3d_nfsd) = &
@@ -139,7 +141,8 @@
 
 #ifdef USE_NETCDF
       call icepack_query_tracer_sizes(ntrcr_out=ntrcr)
-      call icepack_query_tracer_flags(tr_fsd_out=tr_fsd, tr_pond_out=tr_pnd)
+      call icepack_query_tracer_flags(tr_fsd_out=tr_fsd, tr_pond_out=tr_pnd, &
+         tr_pond_topo_out=tr_pnd_topo)
       if (first_call) then
          timcnt = 0
          write(hist_file,'(a,i8.8,a)') './history/icepack.h.',idate,'.nc'
@@ -219,7 +222,11 @@
          enddo
 
          if (tr_pnd) then
-            do n = 1,num_2d_pond
+            numvars = num_2d_pond
+            ! tcraig, July 2025, do not write most of the pond fields for topo ponds, they are not validated yet
+            ! this is a temporary implementation, hardcode to write the first 3 fields only
+            if (tr_pnd_topo) numvars=3
+            do n = 1,numvars
                status = nf90_def_var(ncid,trim(fld_2d_pond(n)),NF90_DOUBLE,dimid2,varid)
                if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR in def_var '//trim(fld_2d_pond(n)))
             enddo
@@ -237,7 +244,11 @@
          enddo
 
          if (tr_pnd) then
-            do n = 1,num_3d_pond
+            numvars = num_3d_pond
+            ! tcraig, July 2025, do not write most of the pond fields for topo ponds, they are not validated yet
+            ! this is a temporary implementation, hardcode to write the first 3 fields only
+            if (tr_pnd_topo) numvars=3
+            do n = 1,numvars
                status = nf90_def_var(ncid,trim(fld_3d_pond(n)),NF90_DOUBLE,dimid3,varid)
                if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR in def_var '//trim(fld_3d_pond(n)))
             enddo
@@ -396,7 +407,11 @@
          start2(2) = timcnt
          count2(2) = 1
 
-         do n = 1,num_2d_pond
+         numvars = num_2d_pond
+         ! tcraig, July 2025, do not write most of the pond fields for topo ponds, they are not validated yet
+         ! this is a temporary implementation, hardcode to write the first 3 fields only
+         if (tr_pnd_topo) numvars=3
+         do n = 1,numvars
             allocate(value2(count2(1),1))
 
             value2 = -9999._dbl_kind
@@ -457,7 +472,11 @@
          start3(3) = timcnt
          count3(3) = 1
 
-         do n = 1,num_3d_pond
+         numvars = num_3d_pond
+         ! tcraig, July 2025, do not write most of the pond fields for topo ponds, they are not validated yet
+         ! this is a temporary implementation, hardcode to write the first 3 fields only
+         if (tr_pnd_topo) numvars=3
+         do n = 1,numvars
             allocate(value3(count3(1),count3(2),1))
 
             value3 = -9999._dbl_kind

--- a/configuration/driver/icedrv_history.F90
+++ b/configuration/driver/icedrv_history.F90
@@ -51,8 +51,9 @@
       use icedrv_flux, only: fswabs, flw, flwout, fsens, fsurf, flat
       use icedrv_flux, only: Tair, Qa, fsw, fcondtop
       use icedrv_flux, only: meltt, meltb, meltl, melts, snoice
-      use icedrv_flux, only: flpndn, expndn, frpndn, rfpndn, ilpndn
-      use icedrv_flux, only: flpnd, expnd, frpnd, rfpnd, ilpnd, mipnd, rdpnd
+      use icedrv_flux, only: dpnd_flushn, dpnd_exponn, dpnd_freebdn, dpnd_initialn, dpnd_dlidn
+      use icedrv_flux, only: dpnd_flush, dpnd_expon, dpnd_freebd, dpnd_initial, dpnd_dlid
+      use icedrv_flux, only: dpnd_melt, dpnd_ridge
       use icedrv_flux, only: dsnow, congel, sst, sss, Tf, fhocn
       use icedrv_arrays_column, only: d_afsd_newi, d_afsd_latg, d_afsd_latm, d_afsd_wave, d_afsd_weld
 #ifdef USE_NETCDF
@@ -101,10 +102,10 @@
       integer (kind=dbl_kind), parameter :: num_2d_pond = 10
       character(len=16), parameter :: fld_2d_pond(num_2d_pond) = &
          (/ 'apnd            ', 'hpnd            ', 'ipnd            ', &
-            'flpnd           ', 'expnd           ', 'frpnd           ', &
-            'rfpnd           ', 'ilpnd           ', 'mipnd           ', &
-            'rdpnd           '  /)
-            
+            'dpnd_flush      ', 'dpnd_expon      ', 'dpnd_freebd     ', &
+            'dpnd_initial    ', 'dpnd_dlid       ', 'dpnd_melt       ', &
+            'dpnd_ridge      '  /)
+
       integer (kind=dbl_kind), parameter :: num_3d_ncat = 3
       character(len=16), parameter :: fld_3d_ncat(num_3d_ncat) = &
          (/ 'aicen           ', 'vicen           ', 'vsnon           ' /)
@@ -121,8 +122,8 @@
       integer (kind=dbl_kind), parameter :: num_3d_pond = 8
       character(len=16), parameter :: fld_3d_pond(num_3d_pond) = &
          (/ 'apndn           ', 'hpndn           ', 'ipndn           ', &
-            'flpndn          ', 'expndn          ', 'frpndn          ', &
-            'rfpndn          ', 'ilpndn          ' /)
+            'dpnd_flushn     ', 'dpnd_exponn     ', 'dpnd_freebdn    ', &
+            'dpnd_initialn   ', 'dpnd_dlidn      ' /)
 
       integer (kind=dbl_kind), parameter :: num_3d_ntrcr = 1
       character(len=16), parameter :: fld_3d_ntrcr(num_3d_ntrcr) = &
@@ -402,13 +403,13 @@
             if (trim(fld_2d_pond(n)) == 'apnd') value2(1:count2(1),1) = trcr(1:count2(1),nt_apnd)
             if (trim(fld_2d_pond(n)) == 'hpnd') value2(1:count2(1),1) = trcr(1:count2(1),nt_hpnd)
             if (trim(fld_2d_pond(n)) == 'ipnd') value2(1:count2(1),1) = trcr(1:count2(1),nt_ipnd)
-            if (trim(fld_2d_pond(n)) == 'flpnd') value2(1:count2(1),1) = flpnd(1:count2(1))
-            if (trim(fld_2d_pond(n)) == 'expnd') value2(1:count2(1),1) = expnd(1:count2(1))
-            if (trim(fld_2d_pond(n)) == 'frpnd') value2(1:count2(1),1) = frpnd(1:count2(1))
-            if (trim(fld_2d_pond(n)) == 'rfpnd') value2(1:count2(1),1) = rfpnd(1:count2(1))
-            if (trim(fld_2d_pond(n)) == 'ilpnd') value2(1:count2(1),1) = ilpnd(1:count2(1))
-            if (trim(fld_2d_pond(n)) == 'mipnd') value2(1:count2(1),1) = mipnd(1:count2(1))
-            if (trim(fld_2d_pond(n)) == 'rdpnd') value2(1:count2(1),1) = rdpnd(1:count2(1))
+            if (trim(fld_2d_pond(n)) == 'dpnd_flush'  ) value2(1:count2(1),1) = dpnd_flush  (1:count2(1))
+            if (trim(fld_2d_pond(n)) == 'dpnd_expon'  ) value2(1:count2(1),1) = dpnd_expon  (1:count2(1))
+            if (trim(fld_2d_pond(n)) == 'dpnd_freebd' ) value2(1:count2(1),1) = dpnd_freebd (1:count2(1))
+            if (trim(fld_2d_pond(n)) == 'dpnd_initial') value2(1:count2(1),1) = dpnd_initial(1:count2(1))
+            if (trim(fld_2d_pond(n)) == 'dpnd_dlid'   ) value2(1:count2(1),1) = dpnd_dlid   (1:count2(1))
+            if (trim(fld_2d_pond(n)) == 'dpnd_melt'   ) value2(1:count2(1),1) = dpnd_melt   (1:count2(1))
+            if (trim(fld_2d_pond(n)) == 'dpnd_ridge'  ) value2(1:count2(1),1) = dpnd_ridge  (1:count2(1))
 
             status = nf90_inq_varid(ncid,trim(fld_2d_pond(n)),varid)
             if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: inq_var '//trim(fld_2d_pond(n)))
@@ -463,11 +464,11 @@
             if (trim(fld_3d_pond(n)) == 'apndn') value3(1:count3(1),1:count3(2),1) = trcrn(1:count3(1),nt_apnd,1:count3(2))
             if (trim(fld_3d_pond(n)) == 'hpndn') value3(1:count3(1),1:count3(2),1) = trcrn(1:count3(1),nt_hpnd,1:count3(2))
             if (trim(fld_3d_pond(n)) == 'ipndn') value3(1:count3(1),1:count3(2),1) = trcrn(1:count3(1),nt_ipnd,1:count3(2))
-            if (trim(fld_3d_pond(n)) == 'flpndn') value3(1:count3(1),1:count3(2),1) = flpndn(1:count3(1),1:count3(2))
-            if (trim(fld_3d_pond(n)) == 'expndn') value3(1:count3(1),1:count3(2),1) = expndn(1:count3(1),1:count3(2))
-            if (trim(fld_3d_pond(n)) == 'frpndn') value3(1:count3(1),1:count3(2),1) = frpndn(1:count3(1),1:count3(2))
-            if (trim(fld_3d_pond(n)) == 'rfpndn') value3(1:count3(1),1:count3(2),1) = rfpndn(1:count3(1),1:count3(2))
-            if (trim(fld_3d_pond(n)) == 'ilpndn') value3(1:count3(1),1:count3(2),1) = ilpndn(1:count3(1),1:count3(2))
+            if (trim(fld_3d_pond(n)) == 'dpnd_flushn'  ) value3(1:count3(1),1:count3(2),1) = dpnd_flushn  (1:count3(1),1:count3(2))
+            if (trim(fld_3d_pond(n)) == 'dpnd_exponn'  ) value3(1:count3(1),1:count3(2),1) = dpnd_exponn  (1:count3(1),1:count3(2))
+            if (trim(fld_3d_pond(n)) == 'dpnd_freebdn' ) value3(1:count3(1),1:count3(2),1) = dpnd_freebdn (1:count3(1),1:count3(2))
+            if (trim(fld_3d_pond(n)) == 'dpnd_initialn') value3(1:count3(1),1:count3(2),1) = dpnd_initialn(1:count3(1),1:count3(2))
+            if (trim(fld_3d_pond(n)) == 'dpnd_dlidn'   ) value3(1:count3(1),1:count3(2),1) = dpnd_dlidn   (1:count3(1),1:count3(2))
 
             status = nf90_inq_varid(ncid,trim(fld_3d_pond(n)),varid)
             if (status /= nf90_noerr) call icedrv_system_abort(string=subname//' ERROR: inq_var '//trim(fld_3d_pond(n)))

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -129,8 +129,8 @@
       use icedrv_flux, only: dsnow, dsnown, faero_atm, faero_ocn
       use icedrv_flux, only: fiso_atm, fiso_ocn, fiso_evap
       use icedrv_flux, only: HDO_ocn, H2_16O_ocn, H2_18O_ocn
-      use icedrv_flux, only: flpndn, expndn, frpndn, rfpndn, ilpndn
-      use icedrv_flux, only: flpnd, expnd, frpnd, rfpnd, ilpnd
+      use icedrv_flux, only: dpnd_flushn, dpnd_exponn, dpnd_freebdn, dpnd_initialn, dpnd_dlidn
+      use icedrv_flux, only: dpnd_flush, dpnd_expon, dpnd_freebd, dpnd_initial, dpnd_dlid
       use icedrv_init, only: lmask_n, lmask_s
       use icedrv_state, only: aice, aicen, aice_init, aicen_init, vicen_init
       use icedrv_state, only: vice, vicen, vsno, vsnon, trcrn, uvel, vvel, vsnon_init
@@ -376,11 +376,11 @@
             lmask_n  = lmask_n(i),    lmask_s   = lmask_s(i),     &
             mlt_onset=mlt_onset(i),   frz_onset = frz_onset(i),   &
             yday = yday,  prescribed_ice = prescribed_ice,        &
-            flpnd    = flpnd(i),      flpndn    = flpndn(i,:),    &
-            expnd    = expnd(i),      expndn    = expndn(i,:),    &
-            frpnd    = frpnd(i),      frpndn   = frpndn(i,:),     &
-            rfpnd    = rfpnd(i),      rfpndn   = rfpndn(i,:),     &
-            ilpnd    = ilpnd(i),      ilpndn   = ilpndn(i,:))
+            dpnd_flush  = dpnd_flush(i),   dpnd_flushn  = dpnd_flushn(i,:),   &
+            dpnd_expon  = dpnd_expon(i),   dpnd_exponn  = dpnd_exponn(i,:),   &
+            dpnd_freebd = dpnd_freebd(i),  dpnd_freebdn = dpnd_freebdn(i,:),  &
+            dpnd_initial= dpnd_initial(i), dpnd_initialn= dpnd_initialn(i,:), &
+            dpnd_dlid   = dpnd_dlid(i),    dpnd_dlidn   = dpnd_dlidn(i,:))
 
         if (tr_aero) then
           do n = 1, ncat
@@ -446,7 +446,7 @@
       use icedrv_flux, only: fsalt, Tf, sss, salinz, fhocn, rsiden, wlat
       use icedrv_flux, only: meltl, frazil_diag, flux_bio, faero_ocn, fiso_ocn
       use icedrv_flux, only: HDO_ocn, H2_16O_ocn, H2_18O_ocn
-      use icedrv_flux, only: mipnd
+      use icedrv_flux, only: dpnd_melt
       use icedrv_init, only: tmask
       use icedrv_state, only: aice, aicen, aice0, trcr_depend
       use icedrv_state, only: aicen_init, vicen_init, trcrn, vicen, vsnon
@@ -531,7 +531,7 @@
                          d_afsd_newi=d_afsd_newi(i,:),                &
                          d_afsd_latm=d_afsd_latm(i,:),                &
                          d_afsd_weld=d_afsd_weld(i,:),                &
-                         mipnd=mipnd(i))
+                         dpnd_melt=dpnd_melt(i))
 
          endif ! tmask
 
@@ -824,7 +824,7 @@
       use icedrv_flux, only: dvirdgdt, opening, closing, fpond, fresh, fhocn
       use icedrv_flux, only: aparticn, krdgn, aredistn, vredistn, dardg1ndt, dardg2ndt
       use icedrv_flux, only: dvirdgndt, araftn, vraftn, fsalt, flux_bio, faero_ocn, fiso_ocn
-      use icedrv_flux, only: rdpnd
+      use icedrv_flux, only: dpnd_ridge
       use icedrv_init, only: tmask
       use icedrv_state, only: trcrn, vsnon, aicen, vicen
       use icedrv_state, only: aice, aice0, trcr_depend, n_trcr_strata
@@ -896,7 +896,7 @@
                          first_ice=first_ice(i,:),                           &
                          flux_bio=flux_bio(i,1:nbtrcr),                      &
                          closing=closing(i),       Tf=Tf(i),                 &
-                         rdpnd=rdpnd(i))
+                         dpnd_ridge=dpnd_ridge(i))
 
          endif ! tmask
 
@@ -936,7 +936,7 @@
                          aice=aice(i),             fsalt=fsalt(i),           &
                          first_ice=first_ice(i,:),                           &
                          flux_bio=flux_bio(i,1:nbtrcr), Tf = Tf(i),          &
-                         rdpnd=rdpnd(i))
+                         dpnd_ridge=dpnd_ridge(i))
 
          endif ! tmask
 

--- a/doc/source/science_guide/sg_thermo.rst
+++ b/doc/source/science_guide/sg_thermo.rst
@@ -127,11 +127,11 @@ ponds, :math:`\rho_i` and :math:`\rho_s` are ice and snow densities,
 :math:`\Delta h_i` and :math:`\Delta h_s` are the thicknesses of ice and
 snow that melted, and :math:`F_{rain}` is the rainfall rate. Namelist
 parameters are set for the level-ice (``tr_pond_lvl``) parameterization;
-in the cesm and topo pond schemes the standard values of :math:`r_{max}`
-and :math:`r_{min}` are 0.7 and 0.15, respectively. For the sealvl pond 
-parameterization, 100% of the melt water is added to the ponds 
-(:math:`r = 1.0`) and runoff is handled by the macro-flaw drainage 
-parameterization (see below).
+in the topo pond scheme the standard values of :math:`r_{max}`
+and :math:`r_{min}` are 0.7 and 0.15, respectively. For the sea-level pond
+parameterization, 100% of the melt water is added to the ponds
+(:math:`r = 1.0`) and runoff is handled by the macro-flaw drainage
+parameterization.
 
 Radiatively, the surface of an ice category is divided into fractions of
 snow, pond and bare ice. In these melt pond schemes, the actual pond
@@ -694,36 +694,36 @@ same mean pond area in a grid cell after the addition of new ice,
 and solving for the new pond area tracer :math:`a_{pnd}^\prime` given
 the newly formed ice area :math:`\Delta a_i = \Delta a_{lvl}`.
 
-sealvl pond formulation (``tr_pond_sealvl`` = true)
+Sea-level pond formulation (``tr_pond_sealvl`` = true)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The sealvl meltpond parameterization was developed based on the
+The sea-level meltpond parameterization was developed based on the
 following observations from field studies and high-resolution (<=1 m)
 satellite and airborne imagery:
 
 * Stage I and II of melt pond formation (initial formation and
   drainage to sea level, respectively) last approximately 2 weeks
-  (:cite:`Eicken04`, :cite:`Polashenski12`, :cite:`Landy14`).
+  :cite:`Eicken04`, :cite:`Polashenski12`, :cite:`Landy14`.
   Therefore melt ponds spend most of their lifespan in Stage III (i.e.,
   pond-air interfaces are at or near sea level and pond-ice interfaces
   are below sea level).
 * On the scale of a CICE grid cell (> 1 km), melt ponds are
   simultaneously observed on thicker and thinner ice; thinner ice
   does not need to be saturated with ponds for there to be ponds on
-  thicker ice (e.g., :cite:`Webster15`, :cite:`Webster22`).
+  thicker ice :cite:`Webster15`, :cite:`Webster22`.
 * For pack ice in the Arctic, Stage III melt pond fraction is rarely
   observed to be below 15% or above 45% on the scale of a CICE grid cell
   (e.g., :cite:`Fetterer98`, :cite:`Tschudi01`, :cite:`Webster15`,
   :cite:`Wright20`). Some remote sensing retrievals show higher
-  pond fractions immediately before the ice melts out (:cite:`Webster15`),
+  pond fractions immediately before the ice melts out :cite:`Webster15`,
   but it is possible that melted-through ponds (i.e.,
   open water) are being misclassified as ponds.
 * Ponds are routinely observed on deformed ice (e.g., :cite:`Eicken04`).
 * When MYI and FYI coexist, observations do not clearly indicate
   consistent differences in pond fraction, although there may be
-  differences in timing (e.g., :cite:`Webster15`, :cite:`Wright20`).
+  differences in timing :cite:`Webster15`, :cite:`Wright20`.
 * Ponded ice albedos do not rapidly increase as pond depth decreases
-  below 20 cm (e.g., :cite:`Light22`).
+  below 20 cm :cite:`Light22`.
 
 The sealvl parameterization assumes that each ice thickness category
 within the grid cell has a subcategory distribution of ice surface
@@ -735,11 +735,11 @@ ice thickness changes). The hypsometric curve is assumed to be linear.
 For each category, the slope and intercept of the hypsometric curve are
 parameterized such that when pond surfaces are at sea level and the
 category is snow-free, the pond area fraction is equal to the namelist
-parameter ``apnd_sl`` (notated as :math:`a_{p,sl}` in :eq:`pndasp`).
+parameter ``apnd_sl`` (notated as :math:`a_{p,sl}` in Eq. :eq:`pndasp`).
 Unless otherwise specified, the sealvl parameterization uses the same
 parameterizations as the level-ice pond scheme. For example, the same
 approach is used to set the effective surface fractions for the Delta-
-Eddington shortwave calculations).
+Eddington shortwave calculations.
 
 *Hypsometry and Pond Depth-Area Relationship.*
 
@@ -756,7 +756,7 @@ category and :math:`a_p` is the pond area fraction of the category.
 Pond meltwater volume is apportioned into depth and area according to
 :math:`pndasp`, with the exception that if the pond area completely
 fills the category :math:`h_p` may exceed :math:`a_p*pndasp`
-(:math:`h_p` is still subject to a freeboard constraint, see below).
+(:math:`h_p` is still subject to a freeboard constraint).
 Unlike in the level-ice parameterization, this use of :math:`pndasp` means
 that when drainage reduces pond volume, both pond area and depth
 decrease; in the level-ice parameterization just depth decreases. In the
@@ -784,7 +784,7 @@ evolution.
 The parameterized hypsometric curve is also used to compute the height
 of the pond surfaces above the mean ice draft (:math:`hpsurf`), which is
 then used in the calculation of hydraulic head for the drainage
-parameterizations (below). :math:`hpsurf` is calculated by
+parameterizations. :math:`hpsurf` is calculated by
 
 .. math::
    hpsurf = h_{in} - pndasp + 2 * pndasp * a_{p}
@@ -811,7 +811,7 @@ in the sealvl scheme.
 * *Percolation Drainage.* Percolation drainage is implemented in the mushy
   thermodynamics scheme. The harmonic mean of the permeability of the
   ice column is estimated, as is the hydraulic head (the height of the
-  pond-air interface above sea level, see above). Then the drainage rate
+  pond-air interface above sea level). Then the drainage rate
   is estimated assuming a Darcy flow. Percolation drainage in the sealvl
   scheme is identical to the level-ice scheme except for the calculation of
   the hydraulic head.
@@ -850,7 +850,7 @@ in the sealvl scheme.
   assumed that all pond water drains from ice undergoing deformation.
 
 * *Pond Lid Refreezing.* Pond lid refreezing and melting in the sealvl
-  scheme is handled in the same manner as in the level-ice scheme (above).
+  scheme is handled in the same manner as in the level-ice scheme.
   The only difference is that in the sealvl scheme the impact of the
   removed/added pond water are distributed according to hypsometry.
 
@@ -869,7 +869,7 @@ optical properties (bare ice IOPs are used). Subsequent research
 transition to bare ice IOPs below 20 cm pond depth. The presence of a
 pond of any measured depth was sufficient to change the apparent optical
 properties. Consequently, the sealvl scheme disables the pond to bare
-ice transition depth assumption (i.e., ``hp0`` = ``hpmin`` = 0.005 m).
+ice transition depth assumption (``hp0`` = ``hpmin`` = 0.005 m).
 
 .. _sfc-forcing:
 

--- a/doc/source/user_guide/interfaces.include
+++ b/doc/source/user_guide/interfaces.include
@@ -464,7 +464,7 @@ icepack_step_ridge
                                       aice,         fsalt,         &
                                       first_ice,                   &
                                       flux_bio,     closing,       &
-                                      Tf,                          &
+                                      Tf,           dpnd_ridge,    &
                                       docleanup,    dorebin)
   
         real (kind=dbl_kind), intent(in) :: &
@@ -536,6 +536,9 @@ icepack_step_ridge
   
         logical (kind=log_kind), dimension(:), intent(inout) :: &
            first_ice    ! true until ice forms
+  
+        real (kind=dbl_kind), intent(inout), optional :: &
+           dpnd_ridge   ! pond drainage due to ridging
   
        logical (kind=log_kind), intent(in), optional ::   &
            docleanup, & ! if false, do not call cleanup_itd (default true)
@@ -785,7 +788,7 @@ icepack_init_parameters
            qqqice_in, TTTice_in, qqqocn_in, TTTocn_in, &
            ktherm_in, conduct_in, fbot_xfer_type_in, calc_Tsfc_in, &
            update_ocn_f_in, ustar_min_in, hi_min_in, a_rapid_mode_in, &
-           cpl_frazil_in, &
+           cpl_frazil_in, semi_implicit_Tsfc_in, vapor_flux_correction_in, &
            Rac_rapid_mode_in, aspect_rapid_mode_in, &
            dSdt_slow_mode_in, phi_c_slow_mode_in, &
            phi_i_mushy_in, shortwave_in, albedo_type_in, albsnowi_in, &
@@ -795,7 +798,7 @@ icepack_init_parameters
            atmbndy_in, calc_strair_in, formdrag_in, highfreq_in, natmiter_in, &
            atmiter_conv_in, calc_dragio_in, &
            tfrz_option_in, kitd_in, kcatbound_in, hs0_in, frzpnd_in, &
-           saltflux_option_in, congel_freeze_in, &
+           apnd_sl_in, saltflux_option_in, congel_freeze_in, &
            floeshape_in, wave_spec_in, wave_spec_type_in, nfreq_in, &
            dpscale_in, rfracmin_in, rfracmax_in, pndaspect_in, hs1_in, hp1_in, &
            bgc_flux_type_in, z_tracers_in, scale_bgc_in, solve_zbgc_in, &
@@ -809,6 +812,7 @@ icepack_init_parameters
            y_sk_DMS_in, t_sk_conv_in, t_sk_ox_in, frazil_scav_in, &
            sw_redist_in, sw_frac_in, sw_dtemp_in, snwgrain_in, &
            snwredist_in, use_smliq_pnd_in, rsnw_fall_in, rsnw_tmax_in, &
+           snw_growth_wet_in, drsnw_min_in, snwliq_max_in, &
            rhosnew_in, rhosmin_in, rhosmax_in, windmin_in, drhosdwind_in, &
            snwlvlfac_in, isnw_T_in, isnw_Tgrd_in, isnw_rhos_in, &
            snowage_rhos_in, snowage_Tgrd_in, snowage_T_in, &
@@ -918,6 +922,9 @@ icepack_init_parameters
            calc_Tsfc_in    , &! if true, calculate surface temperature
                               ! if false, Tsfc is computed elsewhere and
                               ! atmos-ice fluxes are provided to CICE
+           semi_implicit_Tsfc_in   , &! compute dfsurf/dT, dflat/dT terms instead of fsurf, flat
+           vapor_flux_correction_in, &! compute mass/enthalpy correction when evaporation/sublimation
+                              ! computed outside at 0C
            update_ocn_f_in    ! include fresh water and salt fluxes for frazil
   
         real (kind=dbl_kind), intent(in), optional :: &
@@ -1247,7 +1254,7 @@ icepack_init_parameters
         real (kind=dbl_kind), intent(in), optional :: &
            hs0_in             ! snow depth for transition to bare sea ice (m)
   
-        ! level-ice ponds
+        ! level-ice and sealvl ponds
         character (len=*), intent(in), optional :: &
            frzpnd_in          ! pond refreezing parameterization
   
@@ -1257,6 +1264,10 @@ icepack_init_parameters
            rfracmax_in, &     ! maximum retained fraction of meltwater
            pndaspect_in, &    ! ratio of pond depth to pond fraction
            hs1_in             ! tapering parameter for snow on pond ice
+  
+        ! sealvl ponds
+        real (kind=dbl_kind), intent(in), optional :: &
+           apnd_sl_in         ! equilibrium pond fraction for sea level parameterization
   
         ! topo ponds
         real (kind=dbl_kind), intent(in), optional :: &
@@ -1282,7 +1293,10 @@ icepack_init_parameters
            rhosmax_in, &      ! maximum snow density (kg/m^3)
            windmin_in, &      ! minimum wind speed to compact snow (m/s)
            drhosdwind_in, &   ! wind compaction factor (kg s/m^4)
-           snwlvlfac_in       ! fractional increase in snow depth
+           snwlvlfac_in, &    ! fractional increase in snow depth
+           snw_growth_wet_in,&! wet metamorphism parameter (um^3/s)
+           drsnw_min_in, &    ! minimum snow grain growth factor
+           snwliq_max_in      ! irreducible saturation fraction
   
         integer (kind=int_kind), intent(in), optional :: &
            isnw_T_in, &       ! maxiumum temperature index
@@ -1336,15 +1350,15 @@ icepack_query_parameters
            Lfresh_out, cprho_out, Cp_out, ustar_min_out, hi_min_out, a_rapid_mode_out, &
            ktherm_out, conduct_out, fbot_xfer_type_out, calc_Tsfc_out, &
            Rac_rapid_mode_out, aspect_rapid_mode_out, dSdt_slow_mode_out, &
-           phi_c_slow_mode_out, phi_i_mushy_out, shortwave_out, &
-           albedo_type_out, albicev_out, albicei_out, albsnowv_out, &
+           phi_c_slow_mode_out, phi_i_mushy_out, shortwave_out, semi_implicit_Tsfc_out, &
+           albedo_type_out, albicev_out, albicei_out, albsnowv_out, vapor_flux_correction_out, &
            albsnowi_out, ahmax_out, R_ice_out, R_pnd_out, R_snw_out, dT_mlt_out, &
            rsnw_mlt_out, dEdd_algae_out, &
            kalg_out, R_gC2molC_out, kstrength_out, krdg_partic_out, krdg_redist_out, mu_rdg_out, &
            atmbndy_out, calc_strair_out, formdrag_out, highfreq_out, natmiter_out, &
            atmiter_conv_out, calc_dragio_out, &
            tfrz_option_out, kitd_out, kcatbound_out, hs0_out, frzpnd_out, &
-           saltflux_option_out, congel_freeze_out, &
+           apnd_sl_out, saltflux_option_out, congel_freeze_out, &
            floeshape_out, wave_spec_out, wave_spec_type_out, nfreq_out, &
            dpscale_out, rfracmin_out, rfracmax_out, pndaspect_out, hs1_out, hp1_out, &
            bgc_flux_type_out, z_tracers_out, scale_bgc_out, solve_zbgc_out, &
@@ -1358,6 +1372,7 @@ icepack_query_parameters
            y_sk_DMS_out, t_sk_conv_out, t_sk_ox_out, frazil_scav_out, &
            sw_redist_out, sw_frac_out, sw_dtemp_out, snwgrain_out, &
            snwredist_out, use_smliq_pnd_out, rsnw_fall_out, rsnw_tmax_out, &
+           snw_growth_wet_out, drsnw_min_out, snwliq_max_out, &
            rhosnew_out, rhosmin_out, rhosmax_out, windmin_out, drhosdwind_out, &
            snwlvlfac_out, isnw_T_out, isnw_Tgrd_out, isnw_rhos_out, &
            snowage_rhos_out, snowage_Tgrd_out, snowage_T_out, &
@@ -1475,6 +1490,9 @@ icepack_query_parameters
            calc_Tsfc_out    ,&! if true, calculate surface temperature
                               ! if false, Tsfc is computed elsewhere and
                               ! atmos-ice fluxes are provided to CICE
+           semi_implicit_Tsfc_out    ,&! compute dfsurf/dT, dflat/dT terms instead of fsurf, flat
+           vapor_flux_correction_out ,&! compute mass/enthalpy correction when evaporation/sublimation
+                              ! computed outside at 0C
            update_ocn_f_out   ! include fresh water and salt fluxes for frazil
   
         real (kind=dbl_kind), intent(out), optional :: &
@@ -1806,7 +1824,7 @@ icepack_query_parameters
         real (kind=dbl_kind), intent(out), optional :: &
            hs0_out             ! snow depth for transition to bare sea ice (m)
   
-        ! level-ice ponds
+        ! level-ice and sealvl ponds
         character (len=*), intent(out), optional :: &
            frzpnd_out          ! pond refreezing parameterization
   
@@ -1816,6 +1834,10 @@ icepack_query_parameters
            rfracmax_out, &     ! maximum retained fraction of meltwater
            pndaspect_out, &    ! ratio of pond depth to pond fraction
            hs1_out             ! tapering parameter for snow on pond ice
+  
+        ! sealvl ponds
+        real (kind=dbl_kind), intent(out), optional :: &
+           apnd_sl_out         ! equilibrium pond fraction for sea level parameterization
   
         ! topo ponds
         real (kind=dbl_kind), intent(out), optional :: &
@@ -1841,7 +1863,10 @@ icepack_query_parameters
            rhosmax_out, &      ! maximum snow density (kg/m^3)
            windmin_out, &      ! minimum wind speed to compact snow (m/s)
            drhosdwind_out, &   ! wind compaction factor (kg s/m^4)
-           snwlvlfac_out       ! fractional increase in snow depth
+           snwlvlfac_out,  &   ! fractional increase in snow depth
+           snw_growth_wet_out,&! wet metamorphism parameter (um^3/s)
+           drsnw_min_out, &    ! minimum snow grain growth factor
+           snwliq_max_out      ! irreducible saturation fraction
   
         integer (kind=int_kind), intent(out), optional :: &
            isnw_T_out, &       ! maxiumum temperature index
@@ -1995,6 +2020,8 @@ icepack_step_radiation
                                           yday,     sec,       &
                                           swvdr,    swvdf,     &
                                           swidr,    swidf,     &
+                                          swuvrdr,  swuvrdf,   &
+                                          swpardr,  swpardf,   &
                                           coszen,   fsnow,     &
                                           alvdrn,   alvdfn,    &
                                           alidrn,   alidfn,    &
@@ -2004,6 +2031,10 @@ icepack_step_radiation
                                           fswthrun_vdf,        &
                                           fswthrun_idr,        &
                                           fswthrun_idf,        &
+                                          fswthrun_uvrdr,      &
+                                          fswthrun_uvrdf,      &
+                                          fswthrun_pardr,      &
+                                          fswthrun_pardf,      &
                                           fswpenln,            &
                                           Sswabsn,  Iswabsn,   &
                                           albicen,  albsnon,   &
@@ -2023,6 +2054,12 @@ icepack_step_radiation
            fsnow     , & ! snowfall rate (kg/m^2 s)
            TLAT, TLON    ! latitude and longitude (radian)
   
+        real (kind=dbl_kind), intent(in), optional :: &
+           swuvrdr   , & ! sw down, vis uvr dir (W/m^2)
+           swuvrdf   , & ! sw down, vis uvr dif (W/m^2)
+           swpardr   , & ! sw down, vis par dir (W/m^2)
+           swpardf       ! sw down, vis par dif (W/m^2)
+  
         integer (kind=int_kind), intent(in) :: &
            sec           ! elapsed seconds into date
   
@@ -2030,7 +2067,7 @@ icepack_step_radiation
            yday          ! day of the year
   
         character (len=char_len), intent(in), optional :: &
-           calendar_type ! differentiates Gregorian from other calendars
+           calendar_type ! differentiates proleptic_gregorian from other calendars
   
         integer (kind=int_kind), intent(in), optional :: &
            days_per_year ! number of days in one year
@@ -2081,7 +2118,11 @@ icepack_step_radiation
            fswthrun_vdr , & ! vis dir SW through ice to ocean (W/m^2)
            fswthrun_vdf , & ! vis dif SW through ice to ocean (W/m^2)
            fswthrun_idr , & ! nir dir SW through ice to ocean (W/m^2)
-           fswthrun_idf     ! nir dif SW through ice to ocean (W/m^2)
+           fswthrun_idf , & ! nir dif SW through ice to ocean (W/m^2)
+           fswthrun_uvrdr,& ! vis uvr dir SW through ice to ocean (W/m^2)
+           fswthrun_uvrdf,& ! vis uvr dif SW through ice to ocean (W/m^2)
+           fswthrun_pardr,& ! vis par dir SW through ice to ocean (W/m^2)
+           fswthrun_pardf   ! vis par dif SW through ice to ocean (W/m^2)
   
         real (kind=dbl_kind), dimension(:,:), intent(inout) :: &
            fswpenln  , & ! visible SW entering ice layers (W m-2)
@@ -2216,7 +2257,8 @@ icepack_step_therm2
                                        wavefreq,                    &
                                        dwavefreq,                   &
                                        d_afsd_latg,  d_afsd_newi,   &
-                                       d_afsd_latm,  d_afsd_weld)
+                                       d_afsd_latm,  d_afsd_weld,   &
+                                       dpnd_melt)
   
         use icepack_parameters, only: icepack_init_parameters
   
@@ -2259,6 +2301,9 @@ icepack_step_therm2
            meltl    , & ! lateral ice melt         (m/step-->cm/day)
            frazil   , & ! frazil ice growth        (m/step-->cm/day)
            frazil_diag  ! frazil ice growth diagnostic (m/step-->cm/day)
+  
+        real (kind=dbl_kind), intent(inout), optional :: &
+           dpnd_melt    ! pond 'drainage' due to ice melting (m / step)
   
         real (kind=dbl_kind), intent(in), optional :: &
            wlat         ! lateral melt rate (m/s)
@@ -2512,6 +2557,10 @@ icepack_step_therm1
                                       fswthrun_vdf,               &
                                       fswthrun_idr,               &
                                       fswthrun_idf,               &
+                                      fswthrun_uvrdr,             &
+                                      fswthrun_uvrdf,             &
+                                      fswthrun_pardr,             &
+                                      fswthrun_pardf,             &
                                       fswabs      ,               &
                                       flwout      ,               &
                                       Sswabsn     , Iswabsn     , &
@@ -2527,8 +2576,13 @@ icepack_step_therm1
                                       fswthru_vdf ,               &
                                       fswthru_idr ,               &
                                       fswthru_idf ,               &
+                                      fswthru_uvrdr ,             &
+                                      fswthru_uvrdf ,             &
+                                      fswthru_pardr ,             &
+                                      fswthru_pardf ,             &
                                       flatn_f     , fsensn_f    , &
                                       fsurfn_f    , fcondtopn_f , &
+                                      dfsurfdT    , dflatdT     , &
                                       faero_atm   , faero_ocn   , &
                                       fiso_atm    , fiso_ocn    , &
                                       fiso_evap   , &
@@ -2547,7 +2601,12 @@ icepack_step_therm1
                                       lmask_n     , lmask_s     , &
                                       mlt_onset   , frz_onset   , &
                                       yday        , prescribed_ice, &
-                                      zlvs        , afsdn)
+                                      zlvs        , afsdn       , &
+                                      dpnd_flush  , dpnd_flushn , &
+                                      dpnd_expon  , dpnd_exponn , &
+                                      dpnd_freebd , dpnd_freebdn, &
+                                      dpnd_initial, dpnd_initialn, &
+                                      dpnd_dlid   , dpnd_dlidn)
   
         real (kind=dbl_kind), intent(in) :: &
            dt          , & ! time step
@@ -2634,6 +2693,13 @@ icepack_step_therm1
            mlt_onset   , & ! day of year that sfc melting begins
            frz_onset       ! day of year that freezing begins (congel or frazil)
   
+        real (kind=dbl_kind), intent(inout), optional :: &
+           dpnd_flush  , & ! pond flushing rate due to ice permeability (m/step)
+           dpnd_expon  , & ! exponential pond drainage rate (m/step)
+           dpnd_freebd , & ! pond drainage rate due freeboard constraint (m/step)
+           dpnd_initial, & ! runoff rate due to rfrac (m/step)
+           dpnd_dlid       ! pond loss/gain (+/-) to ice lid (m/step)
+  
         real (kind=dbl_kind), intent(out), optional :: &
            wlat            ! lateral melt rate (m/s)
   
@@ -2642,6 +2708,10 @@ icepack_step_therm1
            fswthru_vdf , & ! vis dif shortwave penetrating to ocean (W/m^2)
            fswthru_idr , & ! nir dir shortwave penetrating to ocean (W/m^2)
            fswthru_idf , & ! nir dif shortwave penetrating to ocean (W/m^2)
+           fswthru_uvrdr,& ! vis uvr dir shortwave penetrating to ocean (W/m^2)
+           fswthru_uvrdf,& ! vis uvr dif shortwave penetrating to ocean (W/m^2)
+           fswthru_pardr,& ! vis par dir shortwave penetrating to ocean (W/m^2)
+           fswthru_pardf,& ! vis par dif shortwave penetrating to ocean (W/m^2)
            dsnow       , & ! change in snow depth     (m/step-->cm/day)
            fsloss          ! rate of snow loss to leads      (kg/m^2/s)
   
@@ -2709,6 +2779,13 @@ icepack_step_therm1
            congeln     , & ! congelation ice growth                 (m)
            snoicen         ! snow-ice growth                        (m)
   
+        real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
+           dpnd_flushn , & ! category pond flushing rate          (m/step)
+           dpnd_exponn , & ! exponential pond drainage rate       (m/step)
+           dpnd_freebdn, & ! pond drainage rate due to freeboard  (m/step)
+           dpnd_initialn,& ! runoff rate due to rfrac (m/step)
+           dpnd_dlidn      ! category pond loss/gain due to ice lid (m/step)
+  
         real (kind=dbl_kind), dimension(:), intent(in) :: &
            fswthrun        ! SW through ice to ocean            (W/m^2)
   
@@ -2716,10 +2793,16 @@ icepack_step_therm1
            dsnown          ! change in snow thickness (m/step-->cm/day)
   
         real (kind=dbl_kind), dimension(:), intent(in), optional :: &
+           dfsurfdT     , & ! derivative of fsurfn with respect to temperatur (W m-2 K-1)
+           dflatdT      , & ! derivative of flatn with respect to temperature (W m-2 K-1)
            fswthrun_vdr , & ! vis dir SW through ice to ocean   (W/m^2)
            fswthrun_vdf , & ! vis dif SW through ice to ocean   (W/m^2)
            fswthrun_idr , & ! nir dir SW through ice to ocean   (W/m^2)
-           fswthrun_idf     ! nir dif SW through ice to ocean   (W/m^2)
+           fswthrun_idf , & ! nir dif SW through ice to ocean   (W/m^2)
+           fswthrun_uvrdr,& ! vis uvr dir SW through ice to ocean (W/m^2)
+           fswthrun_uvrdf,& ! vis uvr dif SW through ice to ocean (W/m^2)
+           fswthrun_pardr,& ! vis par dir SW through ice to ocean (W/m^2)
+           fswthrun_pardf   ! via par dif SW through ice to ocean (W/m^2)
   
         real (kind=dbl_kind), dimension(:,:), intent(inout) :: &
            zqsn        , & ! snow layer enthalpy                (J m-3)
@@ -2750,7 +2833,7 @@ icepack_init_tracer_flags
   
         subroutine icepack_init_tracer_flags(&
              tr_iage_in, tr_FY_in, tr_lvl_in, tr_snow_in, &
-             tr_pond_in, tr_pond_lvl_in, tr_pond_topo_in, &
+             tr_pond_in, tr_pond_lvl_in, tr_pond_topo_in, tr_pond_sealvl_in, &
              tr_fsd_in, tr_aero_in, tr_iso_in, tr_brine_in, tr_zaero_in, &
              tr_bgc_Nit_in, tr_bgc_N_in, tr_bgc_DON_in, tr_bgc_C_in, tr_bgc_chl_in, &
              tr_bgc_Am_in, tr_bgc_Sil_in, tr_bgc_DMS_in, tr_bgc_Fe_in, tr_bgc_hum_in, &
@@ -2763,6 +2846,7 @@ icepack_init_tracer_flags
                tr_pond_in      , & ! if .true., use melt pond tracer
                tr_pond_lvl_in  , & ! if .true., use level-ice pond tracer
                tr_pond_topo_in , & ! if .true., use explicit topography-based ponds
+               tr_pond_sealvl_in,& ! if .true., use sealvl pond parameteriztion
                tr_snow_in      , & ! if .true., use snow redistribution or metamorphosis tracers
                tr_fsd_in       , & ! if .true., use floe size distribution tracers
                tr_iso_in       , & ! if .true., use isotope tracers
@@ -2793,7 +2877,7 @@ icepack_query_tracer_flags
   
         subroutine icepack_query_tracer_flags(&
              tr_iage_out, tr_FY_out, tr_lvl_out, tr_snow_out, &
-             tr_pond_out, tr_pond_lvl_out, tr_pond_topo_out, &
+             tr_pond_out, tr_pond_lvl_out, tr_pond_topo_out, tr_pond_sealvl_out, &
              tr_fsd_out, tr_aero_out, tr_iso_out, tr_brine_out, tr_zaero_out, &
              tr_bgc_Nit_out, tr_bgc_N_out, tr_bgc_DON_out, tr_bgc_C_out, tr_bgc_chl_out, &
              tr_bgc_Am_out, tr_bgc_Sil_out, tr_bgc_DMS_out, tr_bgc_Fe_out, tr_bgc_hum_out, &
@@ -2806,6 +2890,7 @@ icepack_query_tracer_flags
                tr_pond_out      , & ! if .true., use melt pond tracer
                tr_pond_lvl_out  , & ! if .true., use level-ice pond tracer
                tr_pond_topo_out , & ! if .true., use explicit topography-based ponds
+               tr_pond_sealvl_out,& ! if .true., use sealvl pond parameterization
                tr_snow_out      , & ! if .true., use snow redistribution or metamorphosis tracers
                tr_fsd_out       , & ! if .true., use floe size distribution
                tr_iso_out       , & ! if .true., use isotope tracers

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -267,6 +267,9 @@ is done by setting ``ICE_IOTYPE`` to ``netcdf`` in **icepack.settings** or using
 ``icepack.setup -s`` option ``ionetcdf``.  If netCDF is used on a particular machine, 
 the machine env and Macros file must support compilation with netCDF.
 
+Note that some of the ponds history fields are not yet implemented for the topo
+ponds option.
+
 .. _bgc-hist:
 
 Biogeochemistry History Fields


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update ponds diagnostics and names
- [X] Developer(s): 
    apcraig, eclare
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Underway
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update the Ponds diagnostics.  Fix a bug that was reporting pond history field values of zero for fields by category.

Rename the ponds history field names.
expnd -> dpnd_expon
flpnd -> dpnd_flush
frpnd -> dpnd_freebd
ilpnd -> dpnd_dlid
mipnd -> dpnd_melt
rdpnd -> dpnd_ridge
rfpnd -> dpnd_initial

Clean up trailing blanks.  Clean up some alignment.

Update the interface documentation

Turn off the dpnd history fields for topo ponds and add a warning message in the output.  Add a note in the documentation that ponds diagnostics are not fully implemented yet for topo ponds.



