### PR TITLE
Fix nag compiler error about kind=8 declaration, change to kind=dbl_kind

### DIFF
--- a/configuration/driver/icedrv_forcing.F90
+++ b/configuration/driver/icedrv_forcing.F90
@@ -1054,10 +1054,10 @@
          status,  &  ! NetCDF status flag
          varid       ! NetCDF variable id
 
-      integer (kind=8), allocatable :: &
+      integer (kind=dbl_kind), allocatable :: &
          data_time(:)   ! array for time array in forcing data
 
-      integer (kind=8), dimension(ntime) :: &
+      integer (kind=dbl_kind), dimension(ntime) :: &
          model_time ! array for Icepack minutely time
 
       real (kind=dbl_kind) :: &
@@ -1102,7 +1102,7 @@
          ! May have strange behavior if dt is not an integer
          model_time0 = (year_init - 1970) * Gregorian_year * 24 * 3600 + time0
          do nt = 1, ntime
-            model_time(nt) = int(model_time0 + dt * nt, kind=8)
+            model_time(nt) = int(model_time0 + dt * nt, kind=dbl_kind)
          enddo
 
          ! Read, average, and interpolate forcing data from each variable
@@ -1290,7 +1290,7 @@
       integer (kind=int_kind), intent(in) :: &
          ncid           ! NetCDF file id
 
-      integer (kind=8), dimension(ntime), intent(in) :: &
+      integer (kind=dbl_kind), dimension(ntime), intent(in) :: &
          model_time     ! model time array
 
       ! Local variables
@@ -1305,7 +1305,7 @@
          nvardims,&  ! number of dimensions for variable
          varid       ! NetCDF variable id
 
-      integer (kind=8), allocatable :: &
+      integer (kind=dbl_kind), allocatable :: &
          data_time(:)   ! array for time array in forcing data
 
       integer, dimension(1) :: &
@@ -1554,10 +1554,10 @@
          status,  &  ! NetCDF status flag
          varid       ! NetCDF variable id
 
-      integer (kind=8), allocatable :: &
+      integer (kind=dbl_kind), allocatable :: &
          data_time(:)   ! array for time array in forcing data
 
-      integer (kind=8), dimension(ntime) :: &
+      integer (kind=dbl_kind), dimension(ntime) :: &
          model_time ! array for Icepack minutely time
 
       real (kind=dbl_kind) :: &
@@ -1604,7 +1604,7 @@
          ! May have strange behavior if dt is not an integer
          model_time0 = (year_init - 1970) * Gregorian_year * 24 * 3600 + time0
          do nt = 1, ntime
-            model_time(nt) = int(model_time0 + dt * nt, kind=8)
+            model_time(nt) = int(model_time0 + dt * nt, kind=dbl_kind)
          enddo
 
          ! Warn if simulation includes leg 4-5 transition


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix nag compiler error about kind=8 declaration, change to kind=dbl_kind
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Nag tests now build and pass.  https://github.com/CICE-Consortium/Test-Results/wiki/icepack_by_hash_forks#b91f1dd73d6c8475e6d94611f592b8036623bf78
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

The nag error was introduced when the MOSAiC forcing was added to Icepack.  It's in the Icepack driver so did not impact CICE testing.  Some new variables were declared (kind=8) which isn't part of the Fortran standard even though most compilers allow it, but the nag compiler generated an error.  The (kind=8) declarations were changed to (kind=dbl_kind).  This should have been addressed sooner, but it should not impact solutions or results for compilers that allow it.