### PR TITLE
Add vicen, vsnon to activate zap_small_areas

### DIFF
--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -1097,8 +1097,8 @@
             call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
             call icepack_warnings_add(subname//' Zap ice: negative ice area')
             return
-         elseif (abs(aicen(n)) /= c0 .and. &
-                 abs(aicen(n)) <= puny) then
+         elseif (abs(aicen(n)) <= puny .and. &
+                 (abs(aicen(n)) /= c0 .or. abs(vicen(n)) /= c0 .or. abs(vsnon(n)) /= c0)) then
 
       !-----------------------------------------------------------------
       ! Account for tracers important for conservation


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Add vicen, vsnon to activate zap_small_areas
- [x] Developer(s): 
    Elizabeth Hunke, Denise Worthen
- [ ] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ufs-weather-model test case reproducer for negative dvice abort 
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [x] more substantial . While differences in values are less than puny, resolves model abort elsewhere originating from ice volume but no area
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [ ] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Floating point math (e.g., in ridge_shift) may lead to tiny vicen increments without area that are not currently zapped. This zaps them too (+ similar logic for tiny vsnon). Closes #535