### PR TITLE
Update the qstat job completion checks

### DIFF
--- a/configuration/scripts/tests/poll_queue.csh
+++ b/configuration/scripts/tests/poll_queue.csh
@@ -13,10 +13,9 @@ foreach line ("`cat suite.jobs`")
   set qstatjob = 1
   if (${job} =~ [0-9]*) then
     while ($qstatjob)
-      ${ICE_MACHINE_QSTAT} $job >&/dev/null
-      set qstatus = $status
-#      echo $job $qstatus
-      if ($qstatus != 0) then
+        set qstatus = `${ICE_MACHINE_QSTAT} $job | grep $job | wc -l`
+#        echo $job $qstatus
+        if ($qstatus == 0) then
         echo "Job $job completed"
         set qstatjob = 0
       else


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update the qstat job completion checks
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Full Icepack test suite run on derecho intel, bit-for-bit and all tests passed.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update the qstat job completion checks to use

  set qstatus = `${ICE_MACHINE_QSTAT} $job | grep $job | wc -l`

Some recent changes made the return status of "${ICE_MACHINE_QSTAT} $job" no longer robust as a way to check if a job was in the queue or not.
