### PR TITLE
add end-quote in index

### DIFF
--- a/doc/source/icepack_index.rst
+++ b/doc/source/icepack_index.rst
@@ -254,7 +254,7 @@ section :ref:`tabnamelist`.
    "istep1", "total number of steps at current time step", ""
    "Iswabs", "shortwave radiation absorbed in ice layers", "W/m\ :math:`^2`"
    "itd_area_min", ":math:`\bullet` zap residual ice below a minimum area", "1.e-11"
-   "itd_mass_min", ":math:`\bullet` zap residual ice below a minimum mass", "1.e-10
+   "itd_mass_min", ":math:`\bullet` zap residual ice below a minimum mass", "1.e-10"
    "**J**", "", ""
    "**K**", "", ""
    "kalg", ":math:`\bullet` absorption coefficient for algae", ""


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
Missing end-quote was preventing documentation index from rendering correctly
- [x] Developer(s): 
@eclare108213 
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
See readthedocs below or direct link: https://cice-consortium-icepack--547.org.readthedocs.build/en/547/appendices/icepack_index.html
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
A one-character change to fix the index of variables in readthedocs.