### PR TITLE
enforce minimum snow grain radius

### DIFF
--- a/columnphysics/icepack_snow.F90
+++ b/columnphysics/icepack_snow.F90
@@ -360,6 +360,9 @@
                hsn(n)   = vsnon(n)/aicen(n)
                hin(n)   = vicen(n)/aicen(n)
             endif
+            do k = 1, nslyr
+               rsnw (k,n) = max(rsnw_fall, rsnw(k,n))
+            enddo
          enddo
 
          call update_snow_radius (dt,                &


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
    Enforce a minimum snow grain radius to prevent NaNs.
- [x] Developer(s): 
    @njeffery 
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.

Results differ for all tests using `snwgrain = .true.` in base_suite:

> 224 measured results of 224 total results
> 219 of 224 tests PASSED
> 0 of 224 tests PENDING
> 0 of 224 tests MISSING data
> 5 of 224 tests FAILED
> (base) Mac-mini:testsuite.snowradius eclare$ ./results.csh  | grep FAIL
> FAIL conda_macos_smoke_col_1x1_bgcispol_debug compare base20260127 different-data
> FAIL conda_macos_smoke_col_1x1_debug_run1year_snw30percent_snwgrain compare base20260127 different-data
> FAIL conda_macos_restart_col_1x1_bgcispol compare base20260127 different-data
> FAIL conda_macos_restart_col_1x1_snwgrain_snwitdrdg_zaero compare base20260127 different-data
> FAIL conda_macos_restart_col_1x1_snwgrain_snwitdrdg compare base20260127 different-data

- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [x] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
If the snow grain radius is set to zero, possibly because of zapping small ice or if ice disappears mid-timestep, then updates of snow grain radius will produce NaNs. Snow grain radius is usually bounded between a min and max so this generally doesn't happen, but a recent coupled E3SM bgc run crashed with this error. While the error seems to be relatively rare, this bug fix changes answers when the snow grain radius is nonzero but still less than the minimum.