### PR TITLE
Fix unsafe comment

### DIFF
--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -3343,7 +3343,7 @@
          !       ---------------------  k-1
          !                k-1
          !       ---------------------  k
-         !       \\\\\\\ ocean \\\\\\\
+         !       /////// ocean ///////
 
          trndir(k+1) = trndir(k)*trnlay(k)
          refkm1      = c1/(c1 - rdndif(k)*rdif_a(k))


### PR DESCRIPTION
Having a comment that ends in \ is not portable across different build systems due to the order and manner in which preprocessing is done. In some cases, like when using ninja, the \ can be interpreted as a line continuation which can silently remove the following line of code.

In this case, the line `trndir(k+1) = trndir(k)*trnlay(k)` was being commented out in the preprocessed file, leading to a very subtle runtime difference in results that took days to track down.

For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Fix unsafe comment with trailing \
- [x] Developer(s): 
    @jgfouca
- [ ] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    Only changes a comment, no testing should be necessary 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
